### PR TITLE
Optional inline SVG workaround

### DIFF
--- a/src/marpit.js
+++ b/src/marpit.js
@@ -34,8 +34,9 @@ class Marpit {
    * @param {boolean} [opts.printable=true] Make style printable to PDF.
    * @param {Element|Element[]} [opts.slideContainer] Container element(s)
    *     wrapping each slide sections.
-   * @param {boolean} [opts.inlineSVG=false] Wrap each sections by inline SVG.
-   *     _(Experimental)_
+   * @param {boolean|'workaround'} [opts.inlineSVG=false] Wrap each sections by
+   *     inline SVG. If you set `workaround`, a few basic styling in theme CSS
+   *     will disable to avoid a rendering bug of Chromium. _(Experimental)_
    */
   constructor(opts = {}) {
     this.options = { ...defaultOptions, ...opts }

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -112,7 +112,7 @@ class ThemeSet {
    * @param {string} name
    * @param {Object} [opts]
    * @param {Element[]} [opts.containers]
-   * @param {boolean} [opts.inlineSVG]
+   * @param {boolean|'workaround'} [opts.inlineSVG]
    * @param {boolean} [opts.printable]
    * @return {string}
    */
@@ -133,7 +133,7 @@ class ThemeSet {
         theme !== scaffold && (css => css.first.before(scaffold.css)),
         postcssPseudoPrepend,
         postcssPseudoReplace(opts.containers, slideElements),
-        opts.inlineSVG && postcssInlineSVGWorkaround,
+        opts.inlineSVG === 'workaround' && postcssInlineSVGWorkaround,
       ].filter(p => p)
     )
 


### PR DESCRIPTION
This PR make inline SVG's CSS workaround optional.

The stable version of Google Chrome still has a possibility to render with broken layout by enabling inline SVG without workaround. But this issue seems to fix in Google Chrome Canary.

The `workaround` option would be useful until a Chrome's implementation become stable.