### PR TITLE
Split the injection of markdown-it plugins and provide interface of markdown-it plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Optional inline SVG workaround ([#1](https://github.com/marp-team/marpit/pull/1))
+* Split the injection of markdown-it plugins and provide interface of markdown-it plugin ([#2](https://github.com/marp-team/marpit/pull/2))
 
 ## v0.0.0 - 2018-03-24
 

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -57,9 +57,21 @@ class Marpit {
     this.applyMarkdownItPlugins()
   }
 
+  /**
+   * The plugin interface of markdown-it for current Marpit instance.
+   *
+   * This is useful to integrate Marpit with the other markdown-it based parser.
+   *
+   * @type {Function}
+   * @readonly
+   */
+  get markdownItPlugins() {
+    return this.applyMarkdownItPlugins.bind(this)
+  }
+
   /** @private */
-  applyMarkdownItPlugins(target = this.markdown) {
-    target
+  applyMarkdownItPlugins(md = this.markdown) {
+    md
       .use(markdownItComment)
       .use(markdownItSlide)
       .use(markdownItParseDirectives, this)
@@ -67,7 +79,7 @@ class Marpit {
       .use(markdownItSlideContainer, this.slideContainers)
       .use(markdownItContainer, this.containers)
 
-    if (this.options.inlineSVG) target.use(markdownItInlineSVG, this)
+    if (this.options.inlineSVG) md.use(markdownItInlineSVG, this)
   }
 
   render(markdown) {

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -54,6 +54,12 @@ class Marpit {
      * @type {MarkdownIt}
      */
     this.markdown = new MarkdownIt(...wrapArray(this.options.markdown))
+    this.applyMarkdownItPlugins()
+  }
+
+  /** @private */
+  applyMarkdownItPlugins(target = this.markdown) {
+    target
       .use(markdownItComment)
       .use(markdownItSlide)
       .use(markdownItParseDirectives, this)
@@ -61,7 +67,7 @@ class Marpit {
       .use(markdownItSlideContainer, this.slideContainers)
       .use(markdownItContainer, this.containers)
 
-    if (this.options.inlineSVG) this.markdown.use(markdownItInlineSVG, this)
+    if (this.options.inlineSVG) target.use(markdownItInlineSVG, this)
   }
 
   render(markdown) {

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -28,6 +28,18 @@ describe('Marpit', () => {
     })
   })
 
+  describe('get #markdownItPlugins', () => {
+    it('provides markdown-it plugins with its compatible interface', () => {
+      const marpit = new Marpit()
+      marpit.themeSet.add('/* @theme foobar */')
+
+      const md = new MarkdownIt().use(marpit.markdownItPlugins)
+      md.render('<!-- theme: foobar -->')
+
+      assert(marpit.lastGlobalDirectives.theme === 'foobar')
+    })
+  })
+
   describe('#render', () => {
     it('returns the object contains html and css member', () => {
       const markdown = '# Hello'


### PR DESCRIPTION
This PR make an injection of markdown-it plugins splitting into `Marpit#applyMarkdownItPlugins` (mark as private).

We will also provide a public interface of markdown-it plugin based on this. It would become to easy to integrate Marpit with a markdown-it based parser (e.g. vscode).

```javascript
import MarkdownIt from 'markdown-it'
import Marpit from '@marp-team/marpit'

const marpit = new Marpit()
marpit.themeSet.add('/* @theme foobar */')

const md = new MarkdownIt().use(marpit.markdownItPlugins)
md.render('<!-- theme: foobar -->')

assert(marpit.lastGlobalDirectives.theme === 'foobar')
```