### PR TITLE
Split rendering style into Marpit#renderStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Optional inline SVG workaround ([#1](https://github.com/marp-team/marpit/pull/1))
 * Split the injection of markdown-it plugins and provide interface of markdown-it plugin ([#2](https://github.com/marp-team/marpit/pull/2))
+* Split rendering style into Marpit#renderStyle ([#3](https://github.com/marp-team/marpit/pull/3))
 * Add JSDoc about `Marpit` class
 
 ## v0.0.0 - 2018-03-24

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -96,15 +96,10 @@ class Marpit {
    * @returns {Marpit~RenderResult} An object of rendering result.
    */
   render(markdown) {
-    const html = this.renderMarkdown(markdown)
-
-    const css = this.themeSet.pack(this.lastGlobalDirectives.theme, {
-      containers: [...this.containers, ...this.slideContainers],
-      inlineSVG: this.options.inlineSVG,
-      printable: this.options.printable,
-    })
-
-    return { html, css }
+    return {
+      html: this.renderMarkdown(markdown),
+      css: this.renderStyle(this.lastGlobalDirectives.theme),
+    }
   }
 
   /**
@@ -118,6 +113,22 @@ class Marpit {
    */
   renderMarkdown(markdown) {
     return this.markdown.render(markdown)
+  }
+
+  /**
+   * Render style by using `themeSet#pack`.
+   *
+   * This method is for internal.
+   *
+   * @param {string|undefined} theme Theme name.
+   * @returns {string} The result string of rendering style.
+   */
+  renderStyle(theme) {
+    return this.themeSet.pack(theme, {
+      containers: [...this.containers, ...this.slideContainers],
+      inlineSVG: this.options.inlineSVG,
+      printable: this.options.printable,
+    })
   }
 }
 

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -108,6 +108,7 @@ class Marpit {
    * This method is for internal. You can override this method if you have to
    * render with customized way.
    *
+   * @private
    * @param {string} markdown A Markdown string.
    * @returns {string} The result string of rendering Markdown.
    */
@@ -120,6 +121,7 @@ class Marpit {
    *
    * This method is for internal.
    *
+   * @private
    * @param {string|undefined} theme Theme name.
    * @returns {string} The result string of rendering style.
    */

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -127,4 +127,19 @@ describe('Marpit', () => {
       assert(instance.renderMarkdown('render') === 'test of render')
     })
   })
+
+  describe('#renderStyle', () => {
+    it('returns the result of themeSet#pack', () => {
+      const instance = new Marpit()
+      instance.themeSet.pack = (theme, opts) => {
+        assert(Object.keys(opts).includes('containers'))
+        assert(Object.keys(opts).includes('inlineSVG'))
+        assert(Object.keys(opts).includes('printable'))
+
+        return `style of ${theme}`
+      }
+
+      assert(instance.renderStyle('test-theme') === 'style of test-theme')
+    })
+  })
 })


### PR DESCRIPTION
It allows CSS rendering customization by the Marpit instance.