### PR TITLE
Add local directives about background image

### DIFF
--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -1,6 +1,6 @@
 /** @module */
 import kebabCase from 'lodash.kebabcase'
-import { globals, locals } from './directives'
+import { appliers, globals, locals } from './directives'
 
 const publicDirectives = [...Object.keys(globals), ...Object.keys(locals)]
 
@@ -41,10 +41,8 @@ function apply(md, opts = {}) {
           .filter(filterFunc)
           .forEach(dir => {
             const value = marpitDirectives[dir]
-            if (value === undefined) return
-
-            // Apply class
-            if (dir === 'class') token.attrJoin('class', value)
+            if (!value) return
+            if (appliers[dir]) appliers[dir](value, { token, styles })
 
             const kebabCaseDir = kebabCase(dir)
             if (dataset) token.attrSet(`data-${kebabCaseDir}`, value)

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -11,41 +11,6 @@
  */
 
 /**
- * @typedef {Function} Applier
- * @param {string} value A value of directive.
- * @param {Object} opts
- * @param {Token} opts.token The slide token of markdown-it.
- * @param {string[]} opts.styles The array of current style definitions.
- */
-
-/**
- * Appliers for directive.
- *
- * @prop {Applier} class Assign `class` attribute to the slide token.
- * @prop {Applier} backgroundImage Add `background-image` style.
- * @prop {Applier} backgroundPosition Add `background-position` style.
- * @prop {Applier} backgroundRepeat Add `background-repeat` style.
- * @prop {Applier} backgroundSize Add `background-size` style.
- */
-export const appliers = {
-  class(value, { token }) {
-    token.attrJoin('class', value)
-  },
-  backgroundImage(value, { styles }) {
-    styles.push(`background-image:${value};`)
-  },
-  backgroundPosition(value, { styles }) {
-    styles.push(`background-position:${value};`)
-  },
-  backgroundRepeat(value, { styles }) {
-    styles.push(`background-repeat:${value};`)
-  },
-  backgroundSize(value, { styles }) {
-    styles.push(`background-size:${value};`)
-  },
-}
-
-/**
  * Global directives.
  *
  * Each global directive assigns to the whole slide deck. If you wrote a same
@@ -74,12 +39,12 @@ export const globals = {
  *
  * @prop {Directive} class Specify HTML class of section element(s).
  * @prop {Directive} backgroundImage Specify background-image style.
- * @prop {Directive} backgroundPosition Specify background-position style. There
- *     is defined `center` as the default style of scaffold.
- * @prop {Directive} backgroundRepeat Specify background-repeat style. There is
- *     defined `no-repeat` as the default style of scaffold.
- * @prop {Directive} backgroundSize Specify background-size style. There is
- *     defined `cover` as the default style of scaffold.
+ * @prop {Directive} backgroundPosition Specify background-position style. The
+ *     default value while setting backgroundImage is `center`.
+ * @prop {Directive} backgroundRepeat Specify background-repeat style. The
+ *     default value while setting backgroundImage is `no-repeat`.
+ * @prop {Directive} backgroundSize Specify background-size style. The default
+ *     value while setting backgroundImage is `cover`.
  */
 export const locals = {
   backgroundImage(value) {
@@ -99,4 +64,4 @@ export const locals = {
   },
 }
 
-export default { appliers, globals, locals }
+export default { globals, locals }

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -11,6 +11,41 @@
  */
 
 /**
+ * @typedef {Function} Applier
+ * @param {string} value A value of directive.
+ * @param {Object} opts
+ * @param {Token} opts.token The slide token of markdown-it.
+ * @param {string[]} opts.styles The array of current style definitions.
+ */
+
+/**
+ * Appliers for directive.
+ *
+ * @prop {Applier} class Assign `class` attribute to the slide token.
+ * @prop {Applier} backgroundImage Add `background-image` style.
+ * @prop {Applier} backgroundPosition Add `background-position` style.
+ * @prop {Applier} backgroundRepeat Add `background-repeat` style.
+ * @prop {Applier} backgroundSize Add `background-size` style.
+ */
+export const appliers = {
+  class(value, { token }) {
+    token.attrJoin('class', value)
+  },
+  backgroundImage(value, { styles }) {
+    styles.push(`background-image:${value};`)
+  },
+  backgroundPosition(value, { styles }) {
+    styles.push(`background-position:${value};`)
+  },
+  backgroundRepeat(value, { styles }) {
+    styles.push(`background-repeat:${value};`)
+  },
+  backgroundSize(value, { styles }) {
+    styles.push(`background-size:${value};`)
+  },
+}
+
+/**
  * Global directives.
  *
  * Each global directive assigns to the whole slide deck. If you wrote a same
@@ -38,11 +73,30 @@ export const globals = {
  * prefix `_` (underbar) to directive name. (Spot directives)
  *
  * @prop {Directive} class Specify HTML class of section element(s).
+ * @prop {Directive} backgroundImage Specify background-image style.
+ * @prop {Directive} backgroundPosition Specify background-position style. There
+ *     is defined `center` as the default style of scaffold.
+ * @prop {Directive} backgroundRepeat Specify background-repeat style. There is
+ *     defined `no-repeat` as the default style of scaffold.
+ * @prop {Directive} backgroundSize Specify background-size style. There is
+ *     defined `cover` as the default style of scaffold.
  */
 export const locals = {
+  backgroundImage(value) {
+    return { backgroundImage: value }
+  },
+  backgroundPosition(value) {
+    return { backgroundPosition: value }
+  },
+  backgroundRepeat(value) {
+    return { backgroundRepeat: value }
+  },
+  backgroundSize(value) {
+    return { backgroundSize: value }
+  },
   class(value) {
     return { class: value }
   },
 }
 
-export default { globals, locals }
+export default { appliers, globals, locals }

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -9,10 +9,6 @@ section {
   box-sizing: border-box;
   overflow: hidden;
 
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: cover;
-
   scroll-snap-align: center center;
 }
 

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -9,6 +9,10 @@ section {
   box-sizing: border-box;
   overflow: hidden;
 
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+
   scroll-snap-align: center center;
 }
 


### PR DESCRIPTION
It supports background image by using Marpit's local directives. This way follows reveal.js.

However, we will not regard that it is the only feature for supporting background image. The pre-released version of Marp have `![bg]()` syntax, and Marpit will follow it by adding a markdown-it plugin to convert syntax. We will work about its implementation as soon as finished work about this PR.

### ToDo

- [ ] Add tests
- [ ] Update CHANGELOG.md
- [ ] Update ToDo section in README.md