### PR TITLE
Convert markdown image syntax with [bg] into directives

### DIFF
--- a/src/helpers/wrap_tokens.js
+++ b/src/helpers/wrap_tokens.js
@@ -26,7 +26,7 @@ function wrapTokens(type, container, tokens) {
   const open = new Token(`${type}_open`, tag, 1)
   const close = new Token(`${type}_close`, tag, -1)
 
-  Object.assign(open, { ...(container.open || {}), children: tokens })
+  Object.assign(open, { ...(container.open || {}) })
   Object.assign(close, { ...(container.close || {}) })
 
   // Assign attributes

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -1,0 +1,35 @@
+/** @module */
+import split from '../helpers/split'
+
+/**
+ * Marpit background image plugin.
+ *
+ * Convert image token with description including `bg`, into `background*` local
+ * directives.
+ *
+ * @alias module:markdown/background_image
+ * @param {MarkdownIt} md markdown-it instance.
+ */
+function backgroundImage(md) {
+  md.core.ruler.after(
+    'marpit_directives_parse',
+    'marpit_background_image',
+    state => {
+      if (state.inlineMode) return
+
+      state.tokens.forEach(tb => {
+        if (tb.type !== 'inline') return
+
+        tb.children.forEach(t => {
+          if (t.type !== 'image') return
+          const props = t.content.split(/\s+/).filter(s => s.length > 0)
+
+          if (!props.includes('bg')) return
+          t.hidden = true
+        })
+      })
+    }
+  )
+}
+
+export default backgroundImage

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -1,5 +1,4 @@
 /** @module */
-import split from '../helpers/split'
 
 /**
  * Marpit background image plugin.
@@ -14,18 +13,48 @@ function backgroundImage(md) {
   md.core.ruler.after(
     'marpit_directives_parse',
     'marpit_background_image',
-    state => {
-      if (state.inlineMode) return
+    ({ inlineMode, tokens, env }) => {
+      // TODO: It would be a more better implementation with using inlineMode
+      if (inlineMode) return
 
-      state.tokens.forEach(tb => {
-        if (tb.type !== 'inline') return
+      let slide
+      tokens.forEach((tb, idx) => {
+        if (tb.type === 'marpit_slide_open') slide = tb
+        if (!slide || tb.type !== 'inline') return
 
         tb.children.forEach(t => {
           if (t.type !== 'image') return
-          const props = t.content.split(/\s+/).filter(s => s.length > 0)
 
+          const props = t.content.split(/\s+/).filter(s => s.length > 0)
           if (!props.includes('bg')) return
+
+          const src = t.attrGet('src')
+          if (src === '') return
+
           t.hidden = true
+
+          slide.meta.marpitDirectives = {
+            ...(slide.meta.marpitDirectives || {}),
+            backgroundImage: `url("${src}")`,
+          }
+
+          // Strip empty paragraph
+          if (md.renderer.renderInline(tb.children, {}, env).match(/^\s*$/)) {
+            tb.hidden = true
+
+            const prevToken = tokens[idx - 1]
+            const nextToken = tokens[idx + 1]
+
+            if (
+              prevToken &&
+              nextToken &&
+              prevToken.type === 'paragraph_open' &&
+              nextToken.type === 'paragraph_close'
+            ) {
+              prevToken.hidden = true
+              nextToken.hidden = true
+            }
+          }
         })
       })
     }

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -3,6 +3,7 @@ import wrapArray from './helpers/wrap_array'
 import ThemeSet from './theme_set'
 import { marpitContainer } from './element'
 import markdownItApplyDirectives from './markdown/directives/apply'
+import markdownItBackgroundImage from './markdown/background_image'
 import markdownItComment from './markdown/comment'
 import markdownItContainer from './markdown/container'
 import markdownItInlineSVG from './markdown/inline_svg'
@@ -11,6 +12,7 @@ import markdownItSlide from './markdown/slide'
 import markdownItSlideContainer from './markdown/slide_container'
 
 const defaultOptions = {
+  backgroundSyntax: true,
   container: marpitContainer,
   markdown: 'commonmark',
   printable: true,
@@ -26,6 +28,8 @@ class Marpit {
    * Create a Marpit instance.
    *
    * @param {Object} [opts]
+   * @param {boolean} [opts.backgroundSyntax=true] Support markdown image syntax
+   *     with description including `bg`.
    * @param {Element|Element[]}
    *     [opts.container={@link module:element.marpitContainer}] Container
    *     element(s) wrapping whole slide deck.
@@ -80,6 +84,7 @@ class Marpit {
       .use(markdownItSlideContainer, this.slideContainers)
       .use(markdownItContainer, this.containers)
 
+    if (this.options.backgroundSyntax) md.use(markdownItBackgroundImage)
     if (this.options.inlineSVG) md.use(markdownItInlineSVG, this)
   }
 

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -1,6 +1,8 @@
 import assert from 'assert'
 import cheerio from 'cheerio'
+import dedent from 'dedent'
 import MarkdownIt from 'markdown-it'
+import comment from '../../src/markdown/comment'
 import backgroundImage from '../../src/markdown/background_image'
 import parseDirectives from '../../src/markdown/directives/parse'
 import slide from '../../src/markdown/slide'
@@ -10,18 +12,70 @@ describe('Marpit background image plugin', () => {
 
   const md = () =>
     new MarkdownIt()
+      .use(comment)
       .use(slide)
       .use(parseDirectives, marpitStub)
       .use(backgroundImage)
 
+  const bgDirective = (url, mdInstance) => {
+    const [first, second] = mdInstance.parse(`![bg](${url})\n\n---`)
+    const secondDirectives = second.meta.marpitDirectives || {}
+
+    assert(secondDirectives.backgroundImage === undefined)
+    return first.meta.marpitDirectives.backgroundImage
+  }
+
+  it('assigns specified image to backgroundImage spot directive', () => {
+    const url = 'https://example.com/bg.jpg'
+    assert(bgDirective(url, md()) === `url("${url}")`)
+  })
+
+  it('escapes doublequote and backslash', () =>
+    assert(bgDirective('"md\\Abg"', md()) === 'url("%22md%5CAbg%22")'))
+
+  it('overrides an already assigned directive', () => {
+    const mdText = `<!-- backgroundImage: url(A) --> ![bg](B)`
+    const [firstSlide] = md().parse(mdText)
+
+    assert(firstSlide.meta.marpitDirectives.backgroundImage === 'url("B")')
+  })
+
   it('does not render the image syntax with bg description as <img>', () => {
-    const $ = cheerio.load(md().render('![bg]() ![notbg]()'))
+    const $ = cheerio.load(md().render('![bg](bgImage) ![notbg](notBgImage)'))
 
     assert($('img').length === 1)
-    assert(
-      $('img')
-        .first()
-        .attr('alt') === 'notbg'
+    assert($('img').attr('alt') === 'notbg')
+    assert($('img').attr('src') === 'notBgImage')
+  })
+
+  it('strips empty paragraph made by background image syntax', () => {
+    const $ = cheerio.load(
+      md().render(dedent`
+        ![bg](stripA)
+
+        ![bg](stripB) ![bg](stripC)
+
+        ![bg](stripD)
+        ![bg](stripE)
+
+        ![notBg](keep)
+
+        ![bg](keep) with contents
+      `)
     )
+
+    assert($('p').length === 2)
+  })
+
+  context('when empty string is specified', () => {
+    it('ignores assign if empty string is specified', () =>
+      assert(bgDirective('', md()) === undefined))
+
+    it('fallbacks to an already assigned directive', () => {
+      const mdText = `<!-- backgroundImage: url(A) --> ![bg]()`
+      const [firstSlide] = md().parse(mdText)
+
+      assert(firstSlide.meta.marpitDirectives.backgroundImage === 'url(A)')
+    })
   })
 })

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -1,0 +1,27 @@
+import assert from 'assert'
+import cheerio from 'cheerio'
+import MarkdownIt from 'markdown-it'
+import backgroundImage from '../../src/markdown/background_image'
+import parseDirectives from '../../src/markdown/directives/parse'
+import slide from '../../src/markdown/slide'
+
+describe('Marpit background image plugin', () => {
+  const marpitStub = { themeSet: new Map() }
+
+  const md = () =>
+    new MarkdownIt()
+      .use(slide)
+      .use(parseDirectives, marpitStub)
+      .use(backgroundImage)
+
+  it('does not render the image syntax with bg description as <img>', () => {
+    const $ = cheerio.load(md().render('![bg]() ![notbg]()'))
+
+    assert($('img').length === 1)
+    assert(
+      $('img')
+        .first()
+        .attr('alt') === 'notbg'
+    )
+  })
+})


### PR DESCRIPTION
This PR will add markdown-it plugin to convert markdown image syntax with `[bg]` into directives (#4).

### ToDo

- [x] Basic feature of Marpit background image plugin
  - [x] Hide image from rendered HTML when it includes `bg` in description
  - [x] Assign `backgroundImage` spot directive\
　
- ~~[Deckset style sizing](https://docs.decksetapp.com/English.lproj/Images%20and%20Videos/01-background-images.html)~~
  - ~~Assign `backgroundSize` spot directive with percentage~~
  - ~~Assign `backgroundSize: contain` spot directive with `fit` keyword~~

EDIT: We will split the implementation of sizing syntax into another PR.

We will implement the filter and multiple background at another PR, by using a SVG data URI scheme to background image.