### PR TITLE
Add version script to update CHANGELOG.md automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "prepack": "npm-run-all --npm-path yarn --parallel format:check lint:all test:coverage --sequential build",
     "preversion": "npm-run-all --npm-path yarn --parallel format:check lint:all test:coverage",
     "test": "cross-env NODE_ENV=test mocha",
-    "test:coverage": "cross-env NODE_ENV=test nyc mocha"
+    "test:coverage": "cross-env NODE_ENV=test nyc mocha",
+    "version": "bash version.sh"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+grep -q '## \[Unreleased\]' CHANGELOG.md &&
+  sed -i "s/## \[Unreleased\]/&\n\n## v$npm_package_version - $(date -u '+%F')/" CHANGELOG.md &&
+  git add -A CHANGELOG.md


### PR DESCRIPTION
I forget updating `CHANGELOG.md` to add the section of tagged version when I update version by `npm version` command. We will add `version.sh` shell script and `version` npm script to work it automatically.