### PR TITLE
Update docs about background images

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,86 @@ Marpit will become a core of _the next version of **[Marp](https://github.com/yh
 * Removed directives about slide size. Use `width` / `height` declaration of theme CSS.
 * Parse directives by YAML parser. ([js-yaml](https://github.com/nodeca/js-yaml) + [`FAILSAFE_SCHEMA`](http://www.yaml.org/spec/1.2/spec.html#id2802346))
 * Support [Jekyll style front-matter](https://jekyllrb.com/docs/frontmatter/).
-* [Global directives](https://github.com/yhatt/marp/blob/master/example.md#global-directives) is no longer requires `$` prefix. (but it still supports because of compatibility and clarity)
-* [Page directives](https://github.com/yhatt/marp/blob/master/example.md#page-directives) is renamed to local directives.
-* Spot directives, that is known as scoped page directive to current slide, has prefix `_`.
+* _[Global directives](https://github.com/yhatt/marp/blob/master/example.md#global-directives)_ is no longer requires `$` prefix. (but it still supports because of compatibility and clarity)
+* [Page directives](https://github.com/yhatt/marp/blob/master/example.md#page-directives) is renamed to _local directives_.
+* _Spot directives_, that is known as scoped page directive to current slide, has prefix `_`.
+
+### Slide backgrounds
+
+We provide a background image syntax to specify slide's background through Markdown. Include `bg` to the alternate text.
+
+```markdown
+![bg](https://example.com/background.jpg)
+```
+
+You can disable by `backgroundSyntax: false` in Marpit constructor option.
+
+#### Resize images
+
+You can resize the image by space-separated options. The basic option value follows `background-size` style (but except length).
+
+```markdown
+`cover` will scale image to fill the slide (default):
+![bg cover](https://example.com/background.jpg)
+
+---
+
+`contain` will scale image to fit the slide:
+![bg contain](https://example.com/background.jpg)
+
+You can also use the `fit` keyword like Deckset:
+![bg fit](https://example.com/background.jpg)
+
+---
+
+`auto` will not scale image, and use the original size:
+![bg auto](https://example.com/background.jpg)
+
+---
+
+The percentage value will specify the scaling factor of image.
+![bg 150%](https://example.com/background.jpg)
+```
+
+#### Styling through directives
+
+If you want to use the gradient as background, you can set style directly through local or spot directives.
+
+This feature is available regardless of `backgroundSyntax` option in Marpit constructor.
+
+```markdown
+<!-- _backgroundImage: "linear-gradient(to bottom, #67b8e3, #0288d1)" -->
+```
+
+Marpit uses YAML for parsing directives, so you should wrap by quote when the value includes space.
+
+##### Directives
+
+| Spot directive        | Description                          | Default     |
+| --------------------- | ------------------------------------ | ----------- |
+| `_backgroundImage`    | Specify `background-image` style.    |             |
+| `_backgroundPosition` | Specify `background-position` style. | `center`    |
+| `_backgroundRepeat`   | Specify `background-repeat` style.   | `no-repeat` |
+| `_backgroundSize`     | Specify `background-size` style.     | `cover`     |
+
+The beginning underbar of directive means "_Apply only to current slide page_". (Spot directive)
+
+When you remove the underbar, the background would apply to current and _the following pages_ (Local directive).
+
+#### Advanced backgrounds with inline SVG mode
+
+The advanced backgrounds will work only with [`inlineSVG: true`](#inline-svg-slide-experimental). It supports multiple background images.
+
+```
+![bg](https://example.com/backgroundA.jpg)
+![bg](https://example.com/backgroundB.jpg)
+```
+
+These images will arrange in a row.
 
 ### ToDo
 
-* [x] Background image (must use _only_ `background-image` style on `<section>`)
-  * [x] Parse `![bg]` syntax
-  * [ ] Auto layouting like Deckset
+* [ ] Background filters in advanced backgrounds
 * [ ] Header and footer directive
 * [ ] Slide page number
 
@@ -132,6 +203,8 @@ When you set `inlineSVG: true` in Marpit constructor option, the each `<section>
 SVG elements can scale contents with keeping aspect ratio. If you are creating an app that integrated Marpit, it would become easy to handle the layout of slides by CSS.
 
 If it combines with [CSS Scroll Snap](https://www.w3.org/TR/css-scroll-snap-1/), _we would not need to require any JavaScript logic_ for the simple HTML-based presentation.
+
+In addition, [the advanced backgrounds](#advanced-backgrounds-with-inline-svg-mode) will support in the layer of this SVG. The injected elements to support advanced background will not affect the DOM structure of each slide.
 
 ## API
 


### PR DESCRIPTION
Marpit has 3 way to specify background images: Styling by directives, Regular background syntax, and Advanced backgrounds with inline SVG.

We update `README.md` to explain these features.