### PR TITLE
Fix PostCSS printable plugin to allow printing advanced backgrounds

### DIFF
--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -27,6 +27,9 @@ const plugin = postcss.plugin('marpit-postcss-printable', opts => css =>
 
   section {
     page-break-before: always;
+  }
+
+  section, section[data-marpit-advanced-background="background"] > figure {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }


### PR DESCRIPTION
This PR will fix printable plugin to allow printing the advanced backgrounds.

The advanced backgrounds + PostCSS printable plugin cannot print backgrounds by default. `color-adjust` style (or `-webkit-print-color-adjust`style) was not applied to the element of advanced bgs.