### PR TITLE
Implement split background in advanced background mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Implement CSS filter for image and advanced backgrounds ([#14](https://github.com/marp-team/marpit/pull/14))
 * Fix PostCSS printable plugin to allow printing the advanced backgrounds ([#15](https://github.com/marp-team/marpit/pull/15))
+* Implement split backgrounds in advanced background mode ([#16](https://github.com/marp-team/marpit/pull/16))
 
 ## v0.0.3 - 2018-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * Support background image syntax ([#4](https://github.com/marp-team/marpit/pull/4), [#5](https://github.com/marp-team/marpit/pull/5), and [#8](https://github.com/marp-team/marpit/pull/8))
 * Add [JSDoc documentation to `ThemeSet` class methods](https://marpit.netlify.com/themeset) ([#7](https://github.com/marp-team/marpit/pull/7))
-* Improve the sweep logic of blank paragraphs by splitted into another plugin ([#8](https://github.com/marp-team/marpit/pull/8))
+* Improve the sweep logic of blank paragraphs by split into another plugin ([#8](https://github.com/marp-team/marpit/pull/8))
 
 ## v0.0.1 - 2018-03-28
 

--- a/README.md
+++ b/README.md
@@ -110,16 +110,43 @@ When you remove the underbar, the background would apply to current and _the fol
 
 #### Advanced backgrounds with inline SVG mode
 
-The advanced backgrounds will work _only with [`inlineSVG: true`](#inline-svg-slide-experimental)_. It supports multiple background images and image filters.
+The advanced backgrounds will work _only with [`inlineSVG: true`](#inline-svg-slide-experimental)_. It supports multiple background images, image filters, and split backgrounds.
 
 ##### Multiple background images
 
-```
+```markdown
 ![bg](https://example.com/backgroundA.jpg)
 ![bg](https://example.com/backgroundB.jpg)
 ```
 
 These images will arrange in a row.
+
+##### Split backgrounds
+
+The `left` or `right` keyword with `bg` keyword make a space for the background to the specified side. It has a half of slide size, and the space of a slide content will shrink too.
+
+```markdown
+![bg left](https://example.com/backgroundA.jpg)
+
+# Slide contents
+
+The space of a slide content will shrink to the right side.
+
+---
+
+<!-- Multiple background images will work well in the specified background side. -->
+
+![bg right](https://example.com/backgroundB.jpg)
+![bg](https://example.com/backgroundC.jpg)
+
+# Slide contents
+
+The space of a slide content will shrink to the left side.
+```
+
+This feature is similar to [Deckset's Split Slides](https://docs.decksetapp.com/English.lproj/Images%20and%20Videos/01-background-images.html).
+
+> Marpit uses a last defined keyword in a slide when `left` and `right` keyword is mixed in the same slide by using multiple background images.
 
 ### Image filters
 

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -20,7 +20,7 @@ const bgSizeKeywords = {
  *
  * When `inlineSVG` option is true, the plugin enables advanced background mode.
  * In addition to the basic background implementation, it supports multiple
- * background images, filters, and splitted background.
+ * background images, filters, and split background.
  *
  * @alias module:markdown/background_image
  * @param {MarkdownIt} md markdown-it instance.

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -20,7 +20,7 @@ const bgSizeKeywords = {
  *
  * When `inlineSVG` option is true, the plugin enables advanced background mode.
  * In addition to the basic background implementation, it supports multiple
- * background images and filters by using SVG.
+ * background images, filters, and splitted background.
  *
  * @alias module:markdown/background_image
  * @param {MarkdownIt} md markdown-it instance.
@@ -40,6 +40,9 @@ function backgroundImage(md) {
           t.meta.marpitImage.options.forEach(opt => {
             if (bgSizeKeywords[opt])
               t.meta.marpitImage.backgroundSize = bgSizeKeywords[opt]
+
+            if (opt === 'left' || opt === 'right')
+              t.meta.marpitImage.backgroundSplit = opt
           })
         }
       })
@@ -69,6 +72,7 @@ function backgroundImage(md) {
                   height: current.svgContent.attrGet('height'),
                   images: current.images,
                   open: current.open,
+                  split: current.split,
                   width: current.svgContent.attrGet('width'),
                 },
               }
@@ -96,6 +100,7 @@ function backgroundImage(md) {
           const {
             background,
             backgroundSize,
+            backgroundSplit,
             filter,
             size,
             url,
@@ -111,6 +116,8 @@ function backgroundImage(md) {
               },
             ]
           }
+
+          if (backgroundSplit) current.split = backgroundSplit
         })
       })
     }
@@ -141,8 +148,17 @@ function backgroundImage(md) {
 
           open.attrSet('data-marpit-advanced-background', 'content')
 
+          const splitSide = foreignObject.meta.marpitBackground.split
+
+          if (splitSide) {
+            open.attrSet('data-marpit-advanced-background-split', splitSide)
+            foreignObject.attrSet('width', '50%')
+
+            if (splitSide === 'left') foreignObject.attrSet('x', '50%')
+          }
+
           advancedBgs = wrapTokens(
-            'marpit_advanced_background_foreign_boejct',
+            'marpit_advanced_background_foreign_object',
             { tag: 'foreignObject', width, height },
             wrapTokens(
               'marpit_advanced_background_section',
@@ -152,21 +168,28 @@ function backgroundImage(md) {
                 id: undefined,
                 'data-marpit-advanced-background': 'background',
               },
-              images.reduce(
-                (imgArr, img) => [
-                  ...imgArr,
-                  ...wrapTokens('marpit_advanced_background_image', {
-                    tag: 'figure',
-                    style: [
-                      `background-image:url("${img.url}");`,
-                      img.size && `background-size:${img.size};`,
-                      img.filter && `filter:${img.filter};`,
-                    ]
-                      .filter(s => s)
-                      .join(''),
-                  }),
-                ],
-                []
+              wrapTokens(
+                'marpit_advanced_background_image_container',
+                {
+                  tag: 'div',
+                  'data-marpit-advanced-background-container': true,
+                },
+                images.reduce(
+                  (imgArr, img) => [
+                    ...imgArr,
+                    ...wrapTokens('marpit_advanced_background_image', {
+                      tag: 'figure',
+                      style: [
+                        `background-image:url("${img.url}");`,
+                        img.size && `background-size:${img.size};`,
+                        img.filter && `filter:${img.filter};`,
+                      ]
+                        .filter(s => s)
+                        .join(''),
+                    }),
+                  ],
+                  []
+                )
               )
             )
           )

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -40,6 +40,7 @@ section[data-marpit-advanced-background="background"] > div[data-marpit-advanced
   background-repeat: no-repeat;
   background-size: cover;
   flex: auto;
+  margin: 0;
 }
 
 section[data-marpit-advanced-background="content"] {

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -1,0 +1,58 @@
+/** @module */
+import postcss from 'postcss'
+
+/**
+ * Marpit PostCSS advanced background plugin.
+ *
+ * Append CSS to suport the advanced background.
+ *
+ * @alias module:postcss/advanced_background
+ */
+const plugin = postcss.plugin(
+  'marpit-postcss-advanced-background',
+  () => css => {
+    css.last.after(
+      `
+section[data-marpit-advanced-background="background"] {
+  padding: 0 !important;
+}
+
+section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] {
+  all: initial;
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+}
+
+section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container] {
+  width: 50%;
+}
+
+section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container] {
+  margin-left: 50%;
+}
+
+section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure {
+  all: initial;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  flex: auto;
+}
+
+section[data-marpit-advanced-background="content"] {
+  background: transparent !important;
+}
+
+section[data-marpit-advanced-background-split] {
+  width: 100%;
+  height: 100%;
+}
+`.trim()
+    )
+  }
+)
+
+export default plugin

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -4,7 +4,7 @@ import postcss from 'postcss'
 /**
  * Marpit PostCSS advanced background plugin.
  *
- * Append CSS to suport the advanced background.
+ * Append style to suport the advanced background.
  *
  * @alias module:postcss/advanced_background
  */

--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -29,15 +29,16 @@ const plugin = postcss.plugin('marpit-postcss-printable', opts => css =>
     page-break-before: always;
   }
 
-  section, section[data-marpit-advanced-background="background"] > figure {
-    -webkit-print-color-adjust: exact;
-    color-adjust: exact;
+  section, section * {
+    -webkit-print-color-adjust: exact !important;
+    color-adjust: exact !important;
   }
 
   :marpit-container > svg {
     display: block;
-    width: 100vw;
     height: 100vh;
+    page-break-before: always;
+    width: 100vw;
   }
 }
 `.trim()

--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -37,7 +37,6 @@ const plugin = postcss.plugin('marpit-postcss-printable', opts => css =>
   :marpit-container > svg {
     display: block;
     height: 100vh;
-    page-break-before: always;
     width: 100vw;
   }
 }

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -17,26 +17,6 @@ h1 {
   font-size: 2em;
   margin: 0.67em 0;
 }
-
-/* Advanced background support */
-section[data-marpit-advanced-background="background"] {
-  display: flex !important;
-  flex-direction: row !important;
-  margin: 0 !important;
-  padding: 0 !important;
-}
-
-section[data-marpit-advanced-background="background"] > figure {
-  all: initial;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  flex: auto;
-}
-
-section[data-marpit-advanced-background="content"] {
-  background: transparent !important;
-}
 `.trim()
 
 /**
@@ -45,7 +25,6 @@ section[data-marpit-advanced-background="content"] {
  * - Define the default slide size.
  * - Set default style for `<section>`.
  * - Normalize `<h1>` heading style.
- * - Support advanced background on inline SVG mode.
  *
  * @alias module:theme/scaffold
  * @type {Theme}

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -1,4 +1,5 @@
 import postcss from 'postcss'
+import postcssAdvancedBackground from './postcss/advanced_background'
 import postcssInlineSVGWorkaround from './postcss/inline_svg_workaround'
 import postcssPrintable from './postcss/printable'
 import postcssPseudoPrepend from './postcss/pseudo_selector/prepend'
@@ -164,6 +165,7 @@ class ThemeSet {
             height: this.getThemeProp(theme, 'height'),
           }),
         theme !== scaffold && (css => css.first.before(scaffold.css)),
+        opts.inlineSVG && postcssAdvancedBackground,
         postcssPseudoPrepend,
         postcssPseudoReplace(opts.containers, slideElements),
         opts.inlineSVG === 'workaround' && postcssInlineSVGWorkaround,

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -195,6 +195,20 @@ describe('Marpit background image plugin', () => {
       assert(foreignObject.attr('x') === '50%')
     })
 
+    context(
+      'when multiple keyword for split background defined in a same slide',
+      () => {
+        const $ = $load(mdSVG().render(`![bg right](a) ![bg left](b)`))
+
+        it('uses the last defined keyword', () => {
+          const section = $('svg > foreignObject:last-child > section')
+          assert(
+            section.attr('data-marpit-advanced-background-split') === 'left'
+          )
+        })
+      }
+    )
+
     context('when filters option of parse image plugin is enabled', () => {
       it('assigns filter style with the function of filter', () => {
         const filters = {

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -9,6 +9,8 @@ import parseDirectives from '../../src/markdown/directives/parse'
 import parseImage from '../../src/markdown/parse_image'
 import slide from '../../src/markdown/slide'
 
+const splitBackgroundKeywords = ['left', 'right']
+
 describe('Marpit background image plugin', () => {
   const marpitStub = svg => ({
     lastGlobalDirectives: {},
@@ -112,11 +114,13 @@ describe('Marpit background image plugin', () => {
 
       const bg = $('svg > foreignObject:first-child')
       const bgSection = bg.find(
-        'section[data-marpit-advanced-background="background"]'
+        '> section[data-marpit-advanced-background="background"]'
       )
       assert(bgSection.length === 1)
 
-      const figure = bgSection.find('figure')
+      const figure = bgSection.find(
+        '> div[data-marpit-advanced-background-container] > figure'
+      )
       assert(figure.length === 1)
       assert(figure.attr('style') === 'background-image:url("image");')
     })
@@ -165,6 +169,30 @@ describe('Marpit background image plugin', () => {
       assert(styleA.includes('background-size:contain;'))
       assert(styleB.includes('background-image:url("B");'))
       assert(styleB.includes('background-size:50%;'))
+    })
+
+    splitBackgroundKeywords.forEach(keyword => {
+      context(`with the ${keyword} keyword for split background`, () => {
+        const $ = $load(mdSVG().render(`![bg ${keyword}](image)`))
+        const foreignObject = $('svg > foreignObject:last-child')
+
+        it('assigns the width attribute of foreignObject for content as 50%', () => {
+          assert(foreignObject.attr('width') === '50%')
+        })
+
+        it('assigns data attribute of the keyword for split background', () => {
+          const section = foreignObject.find('> section')
+          assert(
+            section.attr('data-marpit-advanced-background-split') === keyword
+          )
+        })
+      })
+    })
+
+    it('assigns x attribute of foreignObject for content as 50% with left keyword', () => {
+      const $ = $load(mdSVG().render(`![bg left](image)`))
+      const foreignObject = $('svg > foreignObject:last-child')
+      assert(foreignObject.attr('x') === '50%')
     })
 
     context('when filters option of parse image plugin is enabled', () => {

--- a/test/postcss/advanced_background.js
+++ b/test/postcss/advanced_background.js
@@ -1,0 +1,22 @@
+import assert from 'assert'
+import postcss from 'postcss'
+import advancedBackground from '../../src/postcss/advanced_background'
+
+describe('Marpit PostCSS advanced background plugin', () => {
+  const run = input =>
+    postcss([advancedBackground()]).process(input, { from: undefined })
+
+  const baseCss = 'body { background: #fff; }'
+
+  it('appends style to suport the advanced background', () =>
+    run(baseCss).then(({ root }) => {
+      assert(root.nodes[0].selector === 'body')
+
+      root.nodes.slice(1).forEach(node => {
+        node.selectors.forEach(selector => {
+          assert(selector.startsWith('section'))
+          assert(selector.includes('data-marpit-advanced-background'))
+        })
+      })
+    }))
+})


### PR DESCRIPTION
This PR implements the split background  in advanced background mode. It is similar to a [Deckset's Split Slides feature](https://docs.decksetapp.com/English.lproj/Images%20and%20Videos/01-background-images.html).

The split keyword `left` or `right` in background syntax will make each space of background and content. These don't interfere with another space.

![marpit](https://user-images.githubusercontent.com/3993388/39643065-7abd2cd0-500e-11e8-87dc-ee4ac981c0f8.png)

### ToDo

- [x] Add test cases
