### PR TITLE
Add paginate local directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Add `paginate` local directive ([#17](https://github.com/marp-team/marpit/pull/17))
+
 ## v0.0.4 - 2018-05-05
 
 * Implement CSS filter for image and advanced backgrounds ([#14](https://github.com/marp-team/marpit/pull/14))

--- a/README.md
+++ b/README.md
@@ -37,12 +37,38 @@ Marpit will become a core of _the next version of **[Marp](https://github.com/yh
 
 #### Difference from [pre-released Marp](https://github.com/yhatt/marp/)
 
-* Removed directives about slide size. Use `width` / `height` declaration of theme CSS.
+* Removed directives about slide size. [Use `width` / `height` declaration of theme CSS.](#slide-size)
 * Parse directives by YAML parser. ([js-yaml](https://github.com/nodeca/js-yaml) + [`FAILSAFE_SCHEMA`](http://www.yaml.org/spec/1.2/spec.html#id2802346))
 * Support [Jekyll style front-matter](https://jekyllrb.com/docs/frontmatter/).
 * _[Global directives](https://github.com/yhatt/marp/blob/master/example.md#global-directives)_ is no longer requires `$` prefix. (but it still supports because of compatibility and clarity)
 * [Page directives](https://github.com/yhatt/marp/blob/master/example.md#page-directives) is renamed to _local directives_.
 * _Spot directives_, that is known as scoped page directive to current slide, has prefix `_`.
+
+#### Pagination
+
+We support a pagination by the `paginate` local directive. It is same as [the `page_number` directive in pre-released Marp](https://github.com/yhatt/marp/blob/master/example.md#page_number).
+
+```
+<!-- paginate: true -->
+
+You would be able to see a page number of slide in the lower right.
+```
+
+##### Skip pagination on title slide
+
+Simply you have to move a definition of `paginate` directive to an inside of a second page.
+
+```markdown
+# Title slide
+
+(This page will not paginate by lack of `paginate` local directive)
+
+---
+
+<!-- paginate: true -->
+
+It will paginate slide from a this page.
+```
 
 ### Slide backgrounds
 
@@ -182,7 +208,6 @@ Naturally multiple filters can apply to a image.
 ### ToDo
 
 * [ ] Header and footer directive
-* [ ] Slide page number
 
 ## Markup
 
@@ -226,12 +251,51 @@ section {
   width: 1280px;
   height: 960px;
   font-size: 40px;
+  padding: 40px;
 }
 
 h1 {
   font-size: 60px;
 }
 ```
+
+#### The root `section` selector
+
+In Marpit theme CSS, the root `section` selector means like a viewport of each slide.
+
+##### Slide size
+
+`width` and `height` declaration in `section` selector can specify a slide size. (1280x720 pixels by default)
+
+The specified size is not only used in the section element size but also used in the size of each page of printed PDF.
+
+For example, try these declarations in your theme CSS if you want a classic 4:3 slide:
+
+```css
+section {
+  width: 960px;
+  height: 720px;
+}
+```
+
+Please notice _these must define a length in **an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, and `px`.
+
+##### Styling paginations
+
+You can style the page number through `section::after` pseudo-element. (It is shown by `paginate` local directive)
+
+```css
+section::after {
+  font-weight: bold;
+  text-shadow: 1px 1px 0 #fff;
+}
+```
+
+Please refer to [the default style of `section::after` in a scaffold theme](src/theme/scaffold.js) as well.
+
+> :information_source: The root `section::after` has preserved a content of page number from Marpit. At present, you cannot use the root `section::after` selector for other use.
+
+#### Theme set
 
 The `Marpit` instance has a `themeSet` member that manages usable themes in the `theme` directive of Marpit Markdown. You have to add theme CSS by using `themeSet.add(string)`.
 

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -1,5 +1,4 @@
 /** @module */
-import split from '../helpers/split'
 import wrapTokens from '../helpers/wrap_tokens'
 
 const bgSizeKeywords = {

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -68,7 +68,7 @@ function apply(md, opts = {}) {
             styles['background-size'] = marpitDirectives.backgroundSize
         }
 
-        if (marpitDirectives.pagination)
+        if (marpitDirectives.paginate)
           token.attrSet('data-marpit-pagination', marpitSlide + 1)
 
         const styleStr = Object.keys(styles).reduce(

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -32,7 +32,7 @@ function apply(md, opts = {}) {
       if (state.inlineMode) return
 
       state.tokens.forEach(token => {
-        const { marpitDirectives } = token.meta || {}
+        const { marpitDirectives, marpitSlide } = token.meta || {}
         if (!marpitDirectives) return
 
         const styles = {}
@@ -67,6 +67,9 @@ function apply(md, opts = {}) {
           if (marpitDirectives.backgroundSize)
             styles['background-size'] = marpitDirectives.backgroundSize
         }
+
+        if (marpitDirectives.pagination)
+          token.attrSet('data-marpit-pagination', marpitSlide + 1)
 
         const styleStr = Object.keys(styles).reduce(
           (arr, dir) => `${arr}${dir}:${styles[dir]};`,

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -37,7 +37,6 @@ export const globals = {
  * If you want to set a local directive to single page only, you can add the
  * prefix `_` (underbar) to directive name. (Spot directives)
  *
- * @prop {Directive} class Specify HTML class of section element(s).
  * @prop {Directive} backgroundImage Specify background-image style.
  * @prop {Directive} backgroundPosition Specify background-position style. The
  *     default value while setting backgroundImage is `center`.
@@ -45,6 +44,8 @@ export const globals = {
  *     default value while setting backgroundImage is `no-repeat`.
  * @prop {Directive} backgroundSize Specify background-size style. The default
  *     value while setting backgroundImage is `cover`.
+ * @prop {Directive} class Specify HTML class of section element(s).
+ * @prop {Directive} pagination Show page number on the slide if you set `true`.
  */
 export const locals = {
   backgroundImage(value) {
@@ -61,6 +62,9 @@ export const locals = {
   },
   class(value) {
     return { class: value }
+  },
+  pagination(value) {
+    return { pagination: (value || '').toLowerCase() === 'true' }
   },
 }
 

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -63,8 +63,8 @@ export const locals = {
   class(value) {
     return { class: value }
   },
-  pagination(value) {
-    return { pagination: (value || '').toLowerCase() === 'true' }
+  paginate(value) {
+    return { paginate: (value || '').toLowerCase() === 'true' }
   },
 }
 

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -17,7 +17,8 @@ section[data-marpit-advanced-background="background"] {
   padding: 0 !important;
 }
 
-section[data-marpit-advanced-background="background"]::after {
+section[data-marpit-advanced-background="background"]::after,
+section[data-marpit-advanced-background="content"]::after {
   display: none !important;
 }
 
@@ -47,8 +48,14 @@ section[data-marpit-advanced-background="background"] > div[data-marpit-advanced
   margin: 0;
 }
 
-section[data-marpit-advanced-background="content"] {
+section[data-marpit-advanced-background="content"],
+section[data-marpit-advanced-background="pagination"] {
   background: transparent !important;
+}
+
+section[data-marpit-advanced-background="pagination"],
+:marpit-container > svg > foreignObject[data-marpit-advanced-background="pagination"] {
+  pointer-events: none !important;
 }
 
 section[data-marpit-advanced-background-split] {

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -17,6 +17,10 @@ section[data-marpit-advanced-background="background"] {
   padding: 0 !important;
 }
 
+section[data-marpit-advanced-background="background"]::after {
+  display: none !important;
+}
+
 section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] {
   all: initial;
   display: flex;

--- a/src/postcss/pagination.js
+++ b/src/postcss/pagination.js
@@ -1,65 +1,32 @@
 /** @module */
 import postcss from 'postcss'
 
-const paginateStyle = postcss.parse(
-  `
-section::after {
-  bottom: 0;
-  content: attr(data-marpit-pagination);
-  padding: inherit;
-  pointer-events: none;
-  position: absolute;
-  right: 0;
-}
-`.trim()
-)
-
 /**
  * Marpit PostCSS pagination plugin.
  *
- * Append style to paginate each section by using `::after` pseudo selector.
+ * Marpit uses `section::after` to show the pagination on each slide. It defines
+ * in the scaffold theme.
+ *
+ * This plugin will comment out a `content` declaration defined in any
+ * `section::after` of the root, to prevent override the defined attribute for
+ * paginating.
  *
  * @alias module:postcss/pagination
  */
 const plugin = postcss.plugin('marpit-postcss-pagination', () => css => {
-  const sectionAfters = [paginateStyle.clone()]
-
   css.walkRules(rule => {
-    const sectionAfterSelectors = []
-    const filtered = rule.selectors.filter(selector => {
-      const isSectionAfter = /^section(?![\w-])[^\s>+~]*::?after$/.test(
-        selector.replace(/\[.*?\]/g, '')
-      )
-
-      if (isSectionAfter) sectionAfterSelectors.push(selector)
-      return !isSectionAfter
-    })
-
-    if (sectionAfterSelectors.length > 0) {
-      let newRule = rule.clone({ selectors: sectionAfterSelectors })
-      let targetRule = rule
-
-      while (targetRule.parent) {
-        targetRule = targetRule.parent
-
-        if (
-          targetRule.type === 'atrule' &&
-          !targetRule.name.endsWith('keyframes')
+    if (
+      rule.selectors.some(selector =>
+        /^section(?![\w-])[^\s>+~]*::?after$/.test(
+          selector.replace(/\[.*?\]/g, '')
         )
-          newRule = targetRule.clone({ nodes: [newRule] })
-      }
-
-      sectionAfters.push(newRule)
-    }
-
-    if (filtered.length === 0) {
-      rule.remove()
-    } else {
-      rule.selectors = filtered
-    }
+      )
+    )
+      rule.walkDecls(/^content$/, decl => {
+        if (decl.value !== 'attr(data-marpit-pagination)')
+          decl.replaceWith(`${decl.raw('before')}/* ${decl.toString()}; */`)
+      })
   })
-
-  sectionAfters.forEach(rule => css.last.after(rule))
 })
 
 export default plugin

--- a/src/postcss/pagination.js
+++ b/src/postcss/pagination.js
@@ -1,0 +1,65 @@
+/** @module */
+import postcss from 'postcss'
+
+const paginateStyle = postcss.parse(
+  `
+section::after {
+  bottom: 0;
+  content: attr(data-marpit-pagination);
+  padding: inherit;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+}
+`.trim()
+)
+
+/**
+ * Marpit PostCSS pagination plugin.
+ *
+ * Append style to paginate each section by using `::after` pseudo selector.
+ *
+ * @alias module:postcss/pagination
+ */
+const plugin = postcss.plugin('marpit-postcss-pagination', () => css => {
+  const sectionAfters = [paginateStyle.clone()]
+
+  css.walkRules(rule => {
+    const sectionAfterSelectors = []
+    const filtered = rule.selectors.filter(selector => {
+      const isSectionAfter = /^section(?![\w-])[^\s>+~]*::?after$/.test(
+        selector.replace(/\[.*?\]/g, '')
+      )
+
+      if (isSectionAfter) sectionAfterSelectors.push(selector)
+      return !isSectionAfter
+    })
+
+    if (sectionAfterSelectors.length > 0) {
+      let newRule = rule.clone({ selectors: sectionAfterSelectors })
+      let targetRule = rule
+
+      while (targetRule.parent) {
+        targetRule = targetRule.parent
+
+        if (
+          targetRule.type === 'atrule' &&
+          !targetRule.name.endsWith('keyframes')
+        )
+          newRule = targetRule.clone({ nodes: [newRule] })
+      }
+
+      sectionAfters.push(newRule)
+    }
+
+    if (filtered.length === 0) {
+      rule.remove()
+    } else {
+      rule.selectors = filtered
+    }
+  })
+
+  sectionAfters.forEach(rule => css.last.after(rule))
+})
+
+export default plugin

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -8,6 +8,7 @@ section {
 
   box-sizing: border-box;
   overflow: hidden;
+  position: relative;
 
   scroll-snap-align: center center;
 }

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -13,6 +13,15 @@ section {
   scroll-snap-align: center center;
 }
 
+section::after {
+  bottom: 0;
+  content: attr(data-marpit-pagination);
+  padding: inherit;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+}
+
 /* Normalization */
 h1 {
   font-size: 2em;

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -1,6 +1,7 @@
 import postcss from 'postcss'
 import postcssAdvancedBackground from './postcss/advanced_background'
 import postcssInlineSVGWorkaround from './postcss/inline_svg_workaround'
+import postcssPagination from './postcss/pagination'
 import postcssPrintable from './postcss/printable'
 import postcssPseudoPrepend from './postcss/pseudo_selector/prepend'
 import postcssPseudoReplace from './postcss/pseudo_selector/replace'
@@ -166,6 +167,7 @@ class ThemeSet {
           }),
         theme !== scaffold && (css => css.first.before(scaffold.css)),
         opts.inlineSVG && postcssAdvancedBackground,
+        postcssPagination,
         postcssPseudoPrepend,
         postcssPseudoReplace(opts.containers, slideElements),
         opts.inlineSVG === 'workaround' && postcssInlineSVGWorkaround,

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -272,5 +272,22 @@ describe('Marpit background image plugin', () => {
         })
       })
     })
+
+    context('with paginate directive', () => {
+      const $ = $load(mdSVG().render('<!-- paginate: true --> ![bg](test)'))
+
+      it('appends <foreignObject data-marpit-advanced-background="pagination"> to last', () => {
+        const foreignObjects = $('svg > foreignObject')
+        assert(foreignObjects.length === 3)
+
+        const lastFO = foreignObjects.eq(2)
+        assert(lastFO.is('[data-marpit-advanced-background="pagination"]'))
+        assert(
+          lastFO
+            .find('> section')
+            .is('[data-marpit-advanced-background="pagination"]')
+        )
+      })
+    })
   })
 })

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -178,5 +178,28 @@ describe('Marpit directives apply plugin', () => {
         })
       })
     })
+
+    describe('Paginate', () => {
+      it('applies data-marpit-pagination attribute', () => {
+        const paginateDirs = dedent`
+          ---
+          paginate: true
+          _paginate: false
+          ---
+
+          # Slide 1
+
+          ---
+
+          ## Slide 2
+        `
+
+        const $ = cheerio.load(mdForTest().render(paginateDirs))
+        const sections = $('section')
+
+        assert(!sections.eq(0).data('marpit-pagination'))
+        assert(sections.eq(1).data('marpit-pagination'))
+      })
+    })
   })
 })

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -184,7 +184,7 @@ describe('Marpit directives apply plugin', () => {
         const paginateDirs = dedent`
           ---
           paginate: true
-          _paginate: false
+          _paginate:
           ---
 
           # Slide 1

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -72,7 +72,7 @@ describe('Marpit', () => {
 
         marpit.themeSet.default = marpit.themeSet.add(dedent`
           /* @theme test */
-          section { position: relative; transform: scale(0.9); }
+          section { --theme-defined: declaration; }
         `)
         return marpit
       }
@@ -100,8 +100,7 @@ describe('Marpit', () => {
           .process(rendered.css, { from: undefined })
           .then(ret => {
             assert($('svg > foreignObject > section > h1').length === 1)
-            assert(countDecl(ret.root, 'position') === 1)
-            assert(countDecl(ret.root, 'transform') === 1)
+            assert(countDecl(ret.root, '--theme-defined') === 1)
           })
       })
 

--- a/test/postcss/advanced_background.js
+++ b/test/postcss/advanced_background.js
@@ -14,7 +14,6 @@ describe('Marpit PostCSS advanced background plugin', () => {
 
       root.nodes.slice(1).forEach(node => {
         node.selectors.forEach(selector => {
-          assert(selector.startsWith('section'))
           assert(selector.includes('data-marpit-advanced-background'))
         })
       })

--- a/test/postcss/pagination.js
+++ b/test/postcss/pagination.js
@@ -6,5 +6,78 @@ describe('Marpit PostCSS pagination plugin', () => {
   const run = input =>
     postcss([pagination()]).process(input, { from: undefined })
 
-  // TODO: add test case
+  it('comments out the content declaration of section::after not for pagination', () =>
+    Promise.all([
+      run("section::after { content: 'test'; }").then(result =>
+        assert(result.css === "section::after { /* content: 'test'; */ }")
+      ),
+      run("section:after { content: 'test'; }").then(result =>
+        assert(result.css === "section:after { /* content: 'test'; */ }")
+      ),
+    ]))
+
+  it('comments out the content declaration of section::after with id/class selector', () =>
+    Promise.all([
+      run("section#id::after { content: ''; }").then(result =>
+        assert(result.css === "section#id::after { /* content: ''; */ }")
+      ),
+      run("section.class::after { content: ''; }").then(result =>
+        assert(result.css === "section.class::after { /* content: ''; */ }")
+      ),
+    ]))
+
+  it('comments out the content declaration of section::after with attribute selector', () =>
+    Promise.all([
+      run("section[abc='1']::after { content: ''; }").then(result =>
+        assert(result.css === "section[abc='1']::after { /* content: ''; */ }")
+      ),
+      run("section[abc][def]::after { content: ''; }").then(result =>
+        assert(result.css === "section[abc][def]::after { /* content: ''; */ }")
+      ),
+      run('section[a*="b"]::after { content: \'\'; }').then(result =>
+        assert(result.css === 'section[a*="b"]::after { /* content: \'\'; */ }')
+      ),
+    ]))
+
+  it('comments out the content declaration of section::after with pseudo-class', () =>
+    Promise.all([
+      run("section:hover::after { content: ''; }").then(result =>
+        assert(result.css === "section:hover::after { /* content: ''; */ }")
+      ),
+      run("section:not(:empty)::after { content: ''; }").then(result =>
+        assert(
+          result.css === "section:not(:empty)::after { /* content: ''; */ }"
+        )
+      ),
+    ]))
+
+  it('keeps the content declaration of section::after for pagination', () =>
+    run('section::after { content: attr(data-marpit-pagination); }').then(
+      result =>
+        assert(
+          result.css ===
+            'section::after { content: attr(data-marpit-pagination); }'
+        )
+    ))
+
+  it('keeps the content declaration of section::after with combinators', () =>
+    Promise.all([
+      run("section div::after { content: ''; }").then(result =>
+        assert(result.css === "section div::after { content: ''; }")
+      ),
+      run("section > div::after { content: ''; }").then(result =>
+        assert(result.css === "section > div::after { content: ''; }")
+      ),
+      run("section+section::after { content: ''; }").then(result =>
+        assert(result.css === "section+section::after { content: ''; }")
+      ),
+      run("section~p::after { content: ''; }").then(result =>
+        assert(result.css === "section~p::after { content: ''; }")
+      ),
+    ]))
+
+  it('keeps the content declaration of section-like-element::after', () =>
+    run("section-like-element::after { content: ''; }").then(result =>
+      assert(result.css === "section-like-element::after { content: ''; }")
+    ))
 })

--- a/test/postcss/pagination.js
+++ b/test/postcss/pagination.js
@@ -1,0 +1,19 @@
+import assert from 'assert'
+import dedent from 'dedent'
+import postcss from 'postcss'
+import pagination from '../../src/postcss/pagination'
+
+describe('Marpit PostCSS pagination plugin', () => {
+  const run = input =>
+    postcss([pagination()]).process(input, { from: undefined })
+
+  it('appends changes the order of section::after rule', () =>
+    run(dedent`
+      section::after { background: red; }
+      body { background: white; }
+    `).then(({ root }) => {
+      assert(root.nodes.length === 3)
+      assert(root.nodes[0].selector === 'body')
+      assert(root.nodes[2].selector === 'section::after')
+    }))
+})

--- a/test/postcss/pagination.js
+++ b/test/postcss/pagination.js
@@ -1,5 +1,4 @@
 import assert from 'assert'
-import dedent from 'dedent'
 import postcss from 'postcss'
 import pagination from '../../src/postcss/pagination'
 
@@ -7,13 +6,5 @@ describe('Marpit PostCSS pagination plugin', () => {
   const run = input =>
     postcss([pagination()]).process(input, { from: undefined })
 
-  it('appends changes the order of section::after rule', () =>
-    run(dedent`
-      section::after { background: red; }
-      body { background: white; }
-    `).then(({ root }) => {
-      assert(root.nodes.length === 3)
-      assert(root.nodes[0].selector === 'body')
-      assert(root.nodes[2].selector === 'section::after')
-    }))
+  // TODO: add test case
 })

--- a/test/postcss/pseudo_selector/prepend.js
+++ b/test/postcss/pseudo_selector/prepend.js
@@ -24,6 +24,7 @@ describe('Marpit PostCSS pseudo selector prepending plugin', () => {
   it('replaces section selector into :marpit-slide pseudo element', () => {
     const css = dedent`
       section { background: #fff; }
+      section::after { color: #666; }
       section.invert { background: #000; }
       section-like-element { color: red; }
     `
@@ -33,6 +34,7 @@ describe('Marpit PostCSS pseudo selector prepending plugin', () => {
       result.root.walkRules(rule => rules.push(...rule.selectors))
 
       assert(rules.includes(':marpit-container > :marpit-slide'))
+      assert(rules.includes(':marpit-container > :marpit-slide::after'))
       assert(rules.includes(':marpit-container > :marpit-slide.invert'))
 
       // Custom Elements


### PR DESCRIPTION
This PR implements a `paginate` local directive. the role is as same as [`page_number` page directive on pre-released Marp](https://github.com/yhatt/marp/blob/master/example.md#page_number).

```
# First page

The page number `1` is not shown.

---
<!-- paginate: true -->

# Second page

The page number `2` is shown!
```

To implement this, we have to consider how to style the pagination number in Marpit theme.

- We use `data-marpit-pagination` data attribute to indicate page number.
- The style of `section::after` will use only for the pagination number
- The scaffold theme has a declaration: `content: attr(data-marpit-pagination)`
- PostCSS plugin prevents overriding the content definition of scaffold.

> In Chrome 66 (current stable version), `absolute` and `relative` definition in the `position` declaration will break layout with inline SVG mode. In future, we would require Chrome >= 67 as a recommended browser.

### ToDo

- [x] Add test case
- [x] Update README.md about the rule of theme CSS for `section` selector