### PR TITLE
Add watch npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "preversion": "npm-run-all --npm-path yarn --parallel format:check lint:all test:coverage",
     "test": "cross-env NODE_ENV=test mocha",
     "test:coverage": "cross-env NODE_ENV=test nyc mocha",
-    "version": "bash version.sh"
+    "version": "bash version.sh",
+    "watch": "babel src --out-dir lib -w"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
We had not provided `watch` npm script because of usable in `yarn build -w`.

But it breaks the bundler's `watch` build like webpack or rollup. It causes by removing output directory by `build` npm script through `clean`.

We will provide `watch` script that build without cleaning. It makes a consistent with [marp-team/marp](https://github.com/marp-team/marp) repo.