### PR TITLE
Fix jsdoc about "paginate" local directive prop

### DIFF
--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -49,7 +49,7 @@ export const globals = {
  *     a `<footer>` element to the last of each slide contents.
  * @prop {Directive} header Specify the content of slide header. It will insert
  *     a `<header>` element to the first of each slide contents.
- * @prop {Directive} pagination Show page number on the slide if you set `true`.
+ * @prop {Directive} paginate Show page number on the slide if you set `true`.
  */
 export const locals = {
   backgroundImage(value) {


### PR DESCRIPTION
This PR will fix JSDoc `paginate` local directive prop from `pagination` (the old name).