### PR TITLE
Add Marpit PostCSS import rollup plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add `header` and `footer` directives ([#22](https://github.com/marp-team/marpit/pull/22))
 * Support importing other theme CSS with `@import` (or `@import-theme`) ([#24](https://github.com/marp-team/marpit/pull/24))
-* Add PostCSS import rollup plugin to work `@charset` and `@import` at-rules correctly. ([#26](https://github.com/marp-team/marpit/pull/24))
+* Add PostCSS import rollup plugin to work `@charset` and `@import` at-rules correctly. ([#26](https://github.com/marp-team/marpit/pull/26))
 
 ## v0.0.5 - 2018-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add `header` and `footer` directives ([#22](https://github.com/marp-team/marpit/pull/22))
 * Support importing other theme CSS with `@import` (or `@import-theme`) ([#24](https://github.com/marp-team/marpit/pull/24))
-* Add PostCSS import rollup plugin to work `@charset` and `@import` at-rules correctly. ([#26](https://github.com/marp-team/marpit/pull/26))
+* Add PostCSS import rollup plugin to work `@charset` and `@import` at-rules correctly ([#26](https://github.com/marp-team/marpit/pull/26))
 
 ## v0.0.5 - 2018-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `header` and `footer` directives ([#22](https://github.com/marp-team/marpit/pull/22))
 * Support importing other theme CSS with `@import` (or `@import-theme`) ([#24](https://github.com/marp-team/marpit/pull/24))
+* Add PostCSS import rollup plugin to work `@charset` and `@import` at-rules correctly. ([#26](https://github.com/marp-team/marpit/pull/24))
 
 ## v0.0.5 - 2018-05-12
 

--- a/src/postcss/import/rollup.js
+++ b/src/postcss/import/rollup.js
@@ -1,0 +1,19 @@
+/** @module */
+import postcss from 'postcss'
+
+/**
+ * Marpit PostCSS import rollup plugin.
+ *
+ * Rollup `@charset` and `@import` at-rule to the beginning of CSS. Marpit is
+ * manipulating CSS with many PostCSS plugins, so sometimes a few at-rules
+ * cannot keep specification.
+ *
+ * This plugin takes care of rolling up invalid at-rules.
+ *
+ * @alias module:postcss/import/rollup
+ */
+const plugin = postcss.plugin('marpit-postcss-import-rollup', () => css => {
+  // TODO: Implement rollup plugin
+})
+
+export default plugin

--- a/src/postcss/import/rollup.js
+++ b/src/postcss/import/rollup.js
@@ -13,7 +13,32 @@ import postcss from 'postcss'
  * @alias module:postcss/import/rollup
  */
 const plugin = postcss.plugin('marpit-postcss-import-rollup', () => css => {
-  // TODO: Implement rollup plugin
+  const rolluped = {
+    charset: undefined,
+    imports: [],
+  }
+
+  css.walkAtRules(rule => {
+    if (rule.name === 'charset') {
+      rule.remove()
+      if (!rolluped.charset) rolluped.charset = rule
+    } else if (rule.name === 'import') {
+      rolluped.imports.push(rule.remove())
+    }
+  })
+
+  const { first } = css
+
+  // Rollup at-rules
+  ;[rolluped.charset, ...rolluped.imports]
+    .filter(r => r)
+    .forEach((rule, idx) => {
+      // Strip whitespace from the beginning of first at-rule
+      const prependRule =
+        idx === 0 ? rule.clone({ raws: { before: undefined } }) : rule
+
+      first.before(prependRule)
+    })
 })
 
 export default plugin

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -1,6 +1,7 @@
 import postcss from 'postcss'
 import postcssAdvancedBackground from './postcss/advanced_background'
 import postcssImportReplace from './postcss/import/replace'
+import postcssImportRollup from './postcss/import/rollup'
 import postcssInlineSVGWorkaround from './postcss/inline_svg_workaround'
 import postcssPagination from './postcss/pagination'
 import postcssPrintable from './postcss/printable'
@@ -197,6 +198,7 @@ class ThemeSet {
         postcssPseudoPrepend,
         postcssPseudoReplace(opts.containers, slideElements),
         opts.inlineSVG === 'workaround' && postcssInlineSVGWorkaround,
+        postcssImportRollup,
       ].filter(p => p)
     )
 

--- a/test/postcss/import/rollup.js
+++ b/test/postcss/import/rollup.js
@@ -1,0 +1,35 @@
+import assert from 'assert'
+import dedent from 'dedent'
+import postcss from 'postcss'
+import importRollup from '../../../src/postcss/import/rollup'
+
+describe('Marpit PostCSS import rollup plugin', () => {
+  const run = input =>
+    postcss([importRollup]).process(input, { from: undefined })
+
+  it('rolls up invalid @import rules', () => {
+    const before = dedent`
+      body { background: #fff; }
+      @import 'invalid-import-1';
+      h1 { color: red; }
+      @import 'invalid-import-2';
+    `
+    const after = dedent`
+      @import 'invalid-import-1';
+      @import 'invalid-import-2';
+      body { background: #fff; }
+      h1 { color: red; }
+    `
+    return run(before).then(({ css }) => assert(css === after))
+  })
+
+  it('rolls up invalid @charset rule', () =>
+    run('h1 { color: red; }\n@charset "utf-8";').then(({ css }) =>
+      assert(css === '@charset "utf-8";\nh1 { color: red; }')
+    ))
+
+  it('applies the first rule when style has multiple @charset rules', () =>
+    run('h1 { color: red; }\n@charset "utf-16";\n@charset "utf-8";').then(
+      ({ css }) => assert(css === '@charset "utf-16";\nh1 { color: red; }')
+    ))
+})


### PR DESCRIPTION
Add Marpit PostCSS import rollup plugin. It will roll up `@charset` and `@import` at-rules to the beginning of CSS.

Marpit is manipulating CSS with many PostCSS plugins, so sometimes a few at-rules cannot keep specification. For example, the browser cannot load web fonts if a specified theme was using Google Fonts through `@import`. It is caused by prepending scaffold theme style or printable style.

This plugin takes care of rolling up invalid at-rules to the beginning of CSS. It runs at the last of `themeSet#pack`.

### ToDo

- [x] Implement plugin
- [x] Add test cases
- [x] Update CHANGELOG.md