### PR TITLE
Hide section's after pseudo-element without pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support importing other theme CSS with `@import` (or `@import-theme`) ([#24](https://github.com/marp-team/marpit/pull/24))
 * Add PostCSS import rollup plugin to work `@charset` and `@import` at-rules correctly ([#26](https://github.com/marp-team/marpit/pull/26))
 * Change role of pagination layer to pseudo layer on advanced background ([#27](https://github.com/marp-team/marpit/pull/27))
+* Hide `section::after` pseudo-element without pagination ([#29](https://github.com/marp-team/marpit/pull/29))
 
 ## v0.0.5 - 2018-05-12
 

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -34,6 +34,10 @@ section::after {
   right: 0;
 }
 
+section:not([data-marpit-pagination])::after {
+  display: none;
+}
+
 [data-marpit-emoji] {
   font-family: ${emojiFonts.map(f => `'${f}'`).join(',')};
 }


### PR DESCRIPTION
This PR hides `section::after` pseudo-element for paginate when the slide is not paginated.

When the theme decorates the slide number on `section::after` pseudo-element, the slide that applies `paginate: false` will keep showing decorated element.

### Examples

in [uncover theme](https://github.com/marp-team/marp/blob/3aaf587e597ecc18f2f99422e8c54a689174e273/packages/marp/themes/uncover.scss#L43): *under developing.*

|`paginate: true`|`paginate: false`|
|:---:|:---:|
|![screen shot 2018-05-24 at 19 12 50](https://user-images.githubusercontent.com/3993388/40479612-086f89ec-5f87-11e8-8045-b9b5e2bce322.png)|![screen shot 2018-05-24 at 19 12 40](https://user-images.githubusercontent.com/3993388/40479623-0cb3176c-5f87-11e8-80f3-ac40eb5b548c.png)|

The triangle overlay on `paginate: false` slide would hide when merged this.

If the theme creator wants to always show the pseudo-element for pagination, it can apply `!important` rule to `display` declaration.

```css
section::after {
  /* Always show pseudo-element for pagination */
  display: block !important;
}
```