### PR TITLE
Update version script to work with Mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "preversion": "npm-run-all --npm-path yarn --parallel format:check lint:all test:coverage",
     "test": "cross-env NODE_ENV=test mocha",
     "test:coverage": "cross-env NODE_ENV=test nyc mocha",
-    "version": "bash version.sh",
+    "version": "node version.js",
     "watch": "babel src --out-dir lib -w"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "preversion": "npm-run-all --npm-path yarn --parallel format:check lint:all test:coverage",
     "test": "cross-env NODE_ENV=test mocha",
     "test:coverage": "cross-env NODE_ENV=test nyc mocha",
-    "version": "node version.js",
+    "version": "node version.js && git add -A CHANGELOG.md",
     "watch": "babel src --out-dir lib -w"
   },
   "devDependencies": {

--- a/version.js
+++ b/version.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const unreleased = '## [Unreleased]'
 const [date] = new Date().toISOString().split('T')
-const version = `## ${process.env.npm_package_version} - ${date}`
+const version = `## v${process.env.npm_package_version} - ${date}`
 
 const changelog = path.resolve(__dirname, 'CHANGELOG.md')
 const content = fs.readFileSync(changelog, 'utf8')

--- a/version.js
+++ b/version.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const path = require('path')
+
+const unreleased = '## [Unreleased]'
+const [date] = new Date().toISOString().split('T')
+const version = `## ${process.env.npm_package_version} - ${date}`
+
+const changelog = path.resolve(__dirname, 'CHANGELOG.md')
+const content = fs.readFileSync(changelog, 'utf8')
+
+fs.writeFileSync(
+  changelog,
+  content.replace(unreleased, `${unreleased}\n\n${version}`)
+)

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-grep -q '## \[Unreleased\]' CHANGELOG.md &&
-  sed -i "s/## \[Unreleased\]/&\n\n## v$npm_package_version - $(date -u '+%F')/" CHANGELOG.md &&
-  git add -A CHANGELOG.md


### PR DESCRIPTION
This PR will update npm's version script to work with Mac.

Normally, we are running npm version on Bash (Linux / Windows Git Bash). We have tried version-up on Mac too but it would fail because of using POSIX sed.

We have re-implemented updating logic by Node instead of bash. It would not depend on OS environment.

bonus: [Linguist](https://github.com/github/linguist) for Marpit would show as using only 100% JavaScript.