### PR TITLE
Support backgroundColor and color local directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Support `backgroundColor` and `color` local directives ([#32](https://github.com/marp-team/marpit/pull/32))
+
 ## v0.0.6 - 2018-05-29
 
 - Add `header` and `footer` directives ([#22](https://github.com/marp-team/marpit/pull/22))

--- a/README.md
+++ b/README.md
@@ -162,22 +162,35 @@ The percentage value will specify the scaling factor of image.
 
 #### Styling through directives
 
-If you want to use the gradient as background, you can set style directly through local or spot directives.
-
-This feature is available regardless of `backgroundSyntax` option in Marpit constructor.
+If you want to use any color or the gradient as background, you can set style directly through local or spot directives.
 
 ```markdown
 <!-- _backgroundImage: "linear-gradient(to bottom, #67b8e3, #0288d1)" -->
+
+Gradient background
+
+---
+
+<!--
+_backgroundColor: black
+_color: white
+-->
+
+Black background + White text
 ```
+
+This feature is available regardless of `backgroundSyntax` option in Marpit constructor.
 
 ##### Directives
 
-| Spot directive        | Description                          | Default     |
-| --------------------- | ------------------------------------ | ----------- |
-| `_backgroundImage`    | Specify `background-image` style.    |             |
-| `_backgroundPosition` | Specify `background-position` style. | `center`    |
-| `_backgroundRepeat`   | Specify `background-repeat` style.   | `no-repeat` |
-| `_backgroundSize`     | Specify `background-size` style.     | `cover`     |
+| Spot directive        | Description                                                     | Default     |
+| --------------------- | --------------------------------------------------------------- | ----------- |
+| `_backgroundColor`    | Specify `background-color` style.                               |             |
+| `_backgroundImage`    | Specify `background-image` style.                               |             |
+| `_backgroundPosition` | Specify `background-position` style.                            | `center`    |
+| `_backgroundRepeat`   | Specify `background-repeat` style.                              | `no-repeat` |
+| `_backgroundSize`     | Specify `background-size` style.                                | `cover`     |
+| `_color`              | Specify `color` style. It's usable if the text is hard to read. |             |
 
 The beginning underbar of directive means "_Apply only to current slide page_". (Spot directive)
 

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -53,6 +53,13 @@ function apply(md, opts = {}) {
         if (marpitDirectives.class)
           token.attrJoin('class', marpitDirectives.class)
 
+        if (marpitDirectives.color) style.set('color', marpitDirectives.color)
+
+        if (marpitDirectives.backgroundColor)
+          style
+            .set('background-color', marpitDirectives.backgroundColor)
+            .set('background-image', 'none')
+
         if (marpitDirectives.backgroundImage) {
           style
             .set('background-image', marpitDirectives.backgroundImage)

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -41,6 +41,7 @@ export const globals = {
  * If you want to set a local directive to single page only, you can add the
  * prefix `_` (underbar) to directive name. (Spot directives)
  *
+ * @prop {Directive} backgroundColor Specify background-color style.
  * @prop {Directive} backgroundImage Specify background-image style.
  * @prop {Directive} backgroundPosition Specify background-position style. The
  *     default value while setting backgroundImage is `center`.
@@ -49,6 +50,7 @@ export const globals = {
  * @prop {Directive} backgroundSize Specify background-size style. The default
  *     value while setting backgroundImage is `cover`.
  * @prop {Directive} class Specify HTML class of section element(s).
+ * @prop {Directive} class Specify color style (base text color).
  * @prop {Directive} footer Specify the content of slide footer. It will insert
  *     a `<footer>` element to the last of each slide contents.
  * @prop {Directive} header Specify the content of slide header. It will insert
@@ -56,6 +58,9 @@ export const globals = {
  * @prop {Directive} paginate Show page number on the slide if you set `true`.
  */
 export const locals = {
+  backgroundColor(value) {
+    return { backgroundColor: value }
+  },
   backgroundImage(value) {
     return { backgroundImage: value }
   },
@@ -70,6 +75,9 @@ export const locals = {
   },
   class(value) {
     return { class: value }
+  },
+  color(value) {
+    return { color: value }
   },
   footer(value) {
     return { footer: value }

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -104,10 +104,12 @@ describe('Marpit directives apply plugin', () => {
     describe('Background image', () => {
       const bgDirs = dedent`
         ---
+        backgroundColor: white
         backgroundImage: url(//example.com/a.jpg)
         backgroundPosition: left top
         backgroundRepeat: repeat-y
         backgroundSize: 25%
+        color: black
         ---
       `
 
@@ -116,10 +118,12 @@ describe('Marpit directives apply plugin', () => {
         const section = $('section').first()
         const style = toObjStyle(section.attr('style'))
 
+        assert(style['background-color'] === 'white')
         assert(style['background-image'] === 'url(//example.com/a.jpg)')
         assert(style['background-position'] === 'left top')
         assert(style['background-repeat'] === 'repeat-y')
         assert(style['background-size'] === '25%')
+        assert(style.color === 'black')
       })
 
       context('when directives of image options are not defined', () => {
@@ -185,6 +189,8 @@ describe('Marpit directives apply plugin', () => {
           backgroundPosition: "left;--injection2:injection2"
           backgroundRepeat: "no-repeat;--injection3:injection3"
           backgroundSize: "auto;--injection4:injection4"
+          backgroundColor: "white;--injection5:injection5"
+          color: "black;--injection6:injection6"
           ---
         `
 
@@ -197,10 +203,12 @@ describe('Marpit directives apply plugin', () => {
           assert(style['background-position'] === 'left')
           assert(style['background-repeat'] === 'no-repeat')
           assert(style['background-size'] === 'auto')
-          assert(style['--injection1'] === undefined)
-          assert(style['--injection2'] === undefined)
-          assert(style['--injection3'] === undefined)
-          assert(style['--injection4'] === undefined)
+          assert(style['background-color'] === 'white')
+          assert(style.color === 'black')
+
+          Array.from({ length: 6 }, (v, k) => k + 1).forEach(i =>
+            assert(style[`--injection${i}`] === undefined)
+          )
         })
       })
     })


### PR DESCRIPTION
This PR adds `backgroundColor` and `color` directive to become that it can change the color of a slide.

The pre-released Marp was changing color by `template` directive, but it could change to only predefined colors.

The user may confuse when the theme does not support template because of predefined style resource. (e.g. yhatt/marp#77: The default theme uses GitHub style so we don't support another color scheme)

In some cases, the user would want to use any color scheme. `template` directive (or Marpit's `class` directive) cannot change to a color specified by a user. (e.g. yhatt/marp#221)

Marpit's [inline style support](https://github.com/marp-team/marpit#tweak-theme-in-markdown) would help to apply custom color scheme. However, we thought it's more convenient to have a simple syntax for changing color.

```markdown
---
theme: gaia
backgroundColor: white
---

![bg 50%](https://raw.githubusercontent.com/yhatt/marp/master/images/marp.png)

---

<!-- backgroundColor: black -->

![bg 50%](https://raw.githubusercontent.com/yhatt/marp/master/images/marp.png)

---

<!-- backgroundColor: "#369" -->

![bg 50%](https://raw.githubusercontent.com/yhatt/marp/master/images/marp.png)
```

![bg](https://user-images.githubusercontent.com/3993388/40790100-fd7963ac-652e-11e8-8293-2b886f396d29.png)

`backgroundColor` directive will also set `background-image` declaration as `none` because theme's background image might prevent filling whole a slide by specified color.