### PR TITLE
Update overview on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 It could transform the Markdown and CSS theme(s) to slide deck composed by static HTML and CSS. (powered by [markdown-it](https://github.com/markdown-it/markdown-it) and [PostCSS](https://github.com/postcss/postcss))
 
-- **[Marpit Markdown](#marpit-markdown)** - Based on CommonMark, and have extended _Directives_.
-- **[Clear markup](#markup)** - Marpit theme CSS has no own class, so you can focus on _your_ markup.
-- **[Inline SVG slide](#inline-svg-slide-experimental)** _(Experimental)_ - Support slide auto-scaling without extra JavaScript.
+- **[Marpit Markdown](#marpit-markdown)** - It has extended several features such as [_directives_](#directives) and [_slide backgrounds_](#slide-backgrounds) with keeping a compatibility with the Markdown documents.
+- **[Clear markup](#markup)** - Marpit [theme CSS](#theme-css) has no own class, so you can focus on _your_ markup.
+- **[Inline SVG slide](#inline-svg-slide-experimental)** _(Experimental)_ - Support a browser-native slide auto-scaling. The bare slide deck _has never required JavaScript_.
 
 Marpit will become a core of _the next version of **[Marp](https://github.com/yhatt/marp/)**_.
 


### PR DESCRIPTION
The current overview on README.md has some difference from the actual situation.

1. Marpit Markdown has not limited a base to CommonMark. You can change this in constructor's `markdown` option. ([@marp-team/marp](https://github.com/marp-team/marp/tree/master/packages/marp) would be based on CommonMark)

1. The inline SVG feature is using not only to be auto-scaling a slide but also to isolate the original DOM structure. It allows much advanced DOM manipulating by user JavaScript with keeping Marpit's advanced features. (Principle of least astonishment)

This PR will apply these essences to the overview text.