### PR TITLE
Apply color style to pseudo layer of advanced backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Apply `color` style to pseudo layer of advanced backgrounds ([#37](https://github.com/marp-team/marpit/pull/37))
+
 ## v0.0.7 - 2018-06-04
 
 - Support `backgroundColor` and `color` local directives ([#32](https://github.com/marp-team/marpit/pull/32))

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -1,4 +1,5 @@
 /** @module */
+import InlineStyle from '../helpers/inline_style'
 import wrapTokens from '../helpers/wrap_tokens'
 
 const bgSizeKeywords = {
@@ -191,6 +192,16 @@ function backgroundImage(md) {
         } else if (current && t.type === 'marpit_inline_svg_content_close') {
           const { open, height, width } = current.meta.marpitBackground
 
+          // Apply styles
+          const style = new InlineStyle()
+
+          if (
+            open.meta &&
+            open.meta.marpitDirectives &&
+            open.meta.marpitDirectives.color
+          )
+            style.set('color', open.meta.marpitDirectives.color)
+
           tokens = [
             t,
             ...wrapTokens(
@@ -203,6 +214,7 @@ function backgroundImage(md) {
               },
               wrapTokens('marpit_advanced_pseudo_section', {
                 tag: 'section',
+                style: style.toString(),
                 'data-marpit-advanced-background': 'pseudo',
                 'data-marpit-pagination': open.attrGet(
                   'data-marpit-pagination'

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -304,9 +304,18 @@ describe('Marpit background image plugin', () => {
         const foreignObjects = $('svg > foreignObject')
         assert(foreignObjects.length === 3)
 
-        const lastFO = foreignObjects.eq(2)
-        assert(lastFO.is('[data-marpit-advanced-background="pseudo"]'))
-        assert(lastFO.find('> section').is('[data-marpit-pagination="1"]'))
+        const pseudoFO = foreignObjects.eq(2)
+        assert(pseudoFO.is('[data-marpit-advanced-background="pseudo"]'))
+        assert(pseudoFO.find('> section').is('[data-marpit-pagination="1"]'))
+      })
+    })
+
+    context('with color directive', () => {
+      const $ = $load(mdSVG().render('<!-- color: white -->\n\n![bg](test)'))
+
+      it('assigns color style to pseudo layer', () => {
+        const pseudoSection = $('svg > foreignObject > section').eq(2)
+        assert(pseudoSection.attr('style').includes('color:white;'))
       })
     })
   })


### PR DESCRIPTION
This PR will apply `color` inline style to pseudo layer of advanced backgrounds.

The pseudo layer of background images has not inherited color style assigned by `color` local directive. It means that the customized color would not apply to the pagination when the slide has a background image on inline SVG mode.