### PR TITLE
Fix JSDoc that is missing color prop in the definition of local directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Apply `color` style to pseudo layer of advanced backgrounds ([#37](https://github.com/marp-team/marpit/pull/37))
+- Fix JSDoc: Missing `color` prop in the definition of local directives ([#38](https://github.com/marp-team/marpit/pull/38))
 
 ## v0.0.7 - 2018-06-04
 

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -50,7 +50,7 @@ export const globals = {
  * @prop {Directive} backgroundSize Specify background-size style. The default
  *     value while setting backgroundImage is `cover`.
  * @prop {Directive} class Specify HTML class of section element(s).
- * @prop {Directive} class Specify color style (base text color).
+ * @prop {Directive} color Specify color style (base text color).
  * @prop {Directive} footer Specify the content of slide footer. It will insert
  *     a `<footer>` element to the last of each slide contents.
  * @prop {Directive} header Specify the content of slide header. It will insert


### PR DESCRIPTION
We have double `class` props on JSDoc. My bad 😛