### PR TITLE
Add the basic TypeScript definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add the basic TypeScript definition ([#40](https://github.com/marp-team/marpit/pull/40))
+
 ## v0.0.8 - 2018-06-28
 
 - Apply `color` style to pseudo layer of advanced backgrounds ([#37](https://github.com/marp-team/marpit/pull/37))

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,6 @@ declare module '@marp-team/marpit' {
     inlineSVG?: boolean
   }
 
-  type MarkdownIt = any
-  type PostCSSAtRule = any
-
   type MarpitRenderResult = {
     html: string
     css: string
@@ -28,14 +25,14 @@ declare module '@marp-team/marpit' {
   export class Marpit {
     constructor(opts?: MarpitOptions)
 
-    markdown: MarkdownIt
+    markdown: any
     themeSet: ThemeSet
 
-    readonly markdownItPlugins: (md: MarkdownIt) => void
+    readonly markdownItPlugins: (md: any) => void
 
     render(markdown: string): MarpitRenderResult
 
-    protected applyMarkdownItPlugins(md: MarkdownIt): void
+    protected applyMarkdownItPlugins(md: any): void
     protected renderMarkdown(markdown: string): string
     protected renderStyle(theme?: string): string
   }
@@ -55,7 +52,7 @@ declare module '@marp-team/marpit' {
     css: string
     height: string
     importRules: {
-      node: PostCSSAtRule
+      node: any
       value: string
     }[]
     meta: {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,87 @@
-// TODO: Add definition of Marpit and exported classes for TypeScript
+declare module '@marp-team/marpit' {
+  interface MarpitOptions {
+    backgroundSyntax?: boolean
+    container?: Element | Element[]
+    filters?: boolean
+    inlineStyle?: boolean
+    markdown?: string | object | [string, object]
+    printable?: boolean
+    slideContainer?: Element | Element[]
+    inlineSVG?: boolean
+  }
+
+  type MarkdownIt = any
+  type PostCSSAtRule = any
+
+  type MarpitRenderResult = {
+    html: string
+    css: string
+  }
+
+  type ThemeSetPackOptions = {
+    appendStyle?: string
+    containers?: Element[]
+    printable?: boolean
+    inlineSVG?: boolean
+  }
+
+  export class Marpit {
+    constructor(opts?: MarpitOptions)
+
+    markdown: MarkdownIt
+    themeSet: ThemeSet
+
+    readonly markdownItPlugins: (md: MarkdownIt) => void
+
+    render(markdown: string): MarpitRenderResult
+
+    protected applyMarkdownItPlugins(md: MarkdownIt): void
+    protected renderMarkdown(markdown: string): string
+    protected renderStyle(theme?: string): string
+  }
+
+  export class Element {
+    constructor(tag: string, attributes?: {})
+
+    [index: string]: any
+    tag: string
+  }
+
+  export class Theme {
+    protected constructor(name: string, css: string)
+
+    static fromCSS(cssString: string): Theme
+
+    css: string
+    height: string
+    importRules: {
+      node: PostCSSAtRule
+      value: string
+    }[]
+    meta: {}
+    name: string
+    width: string
+
+    readonly heightPixel?: number
+    readonly widthPixel?: number
+  }
+
+  export class ThemeSet {
+    constructor()
+
+    default?: Theme
+
+    readonly size: number
+    private readonly themeMap: Map<string, Theme>
+
+    add(css: string): Theme
+    addTheme(theme: Theme): void
+    clear(): void
+    delete(name: string): boolean
+    get(name: string, fallback?: boolean): Theme | undefined
+    getThemeProp(theme: string | Theme, prop: string): any
+    has(name: string): boolean
+    pack(name: string, opts: ThemeSetPackOptions): string
+    themes(): IterableIterator<Theme>
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare module '@marp-team/marpit' {
     clear(): void
     delete(name: string): boolean
     get(name: string, fallback?: boolean): Theme | undefined
-    getThemeProp(theme: string | Theme, prop: string): any
+    getThemeProp(theme: string | Theme, prop: keyof Theme): any
     has(name: string): boolean
     pack(name: string, opts: ThemeSetPackOptions): string
     themes(): IterableIterator<Theme>

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare module '@marp-team/marpit' {
   export class ThemeSet {
     constructor()
 
-    default?: Theme
+    default: Theme | undefined
 
     readonly size: number
     private readonly themeMap: Map<string, Theme>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+// TODO: Add definition of Marpit and exported classes for TypeScript

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare module '@marp-team/marpit' {
   export class ThemeSet {
     constructor()
 
-    default: Theme | undefined
+    default?: Theme
 
     readonly size: number
     private readonly themeMap: Map<string, Theme>

--- a/package.json
+++ b/package.json
@@ -26,15 +26,17 @@
     "url": "https://github.com/marp-team/marpit"
   },
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "files": [
-    "lib/"
+    "lib/",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "yarn --mutex file run clean && babel src --out-dir lib",
     "clean": "rimraf lib",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "docs": "jsdoc src -c .jsdoc.json",
-    "format": "prettier **/*.{md,json}",
+    "format": "prettier **/*.{md,json,ts}",
     "format:check": "yarn --mutex file run format -l",
     "lint": "eslint",
     "lint:all": "eslint .",


### PR DESCRIPTION
This PR adds `index.d.ts` type definition file for TypeScript. `@marp-team/marp-core` is now developing with TypeScript, so type hints would be supported efficient developing of Marp.

`index.d.ts` covers the Marpit's public API: `Marpit`, `Theme`, `ThemeSet`, and `Element`.

However, we are not familiar with TS. At moment, we are planning on taking manage the each of JavaScript code base, JSDoc (on main code), and TypeScript definition. In near future, we would migrate the code from JS into TS.