### PR TITLE
Support heading divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add the basic TypeScript definition ([#40](https://github.com/marp-team/marpit/pull/40))
+- Support heading divider ([#41](https://github.com/marp-team/marpit/pull/41))
 
 ## v0.0.8 - 2018-06-28
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,62 @@ footer: "![image](https://example.com/image.jpg)"
 
 > :information_source: Due to the parsing order of Markdown, you cannot use [slide background images](#slide-background) in `header` and `footer` directives.
 
+#### [PLANNING] Heading divider
+
+This feature is similar to [Pandoc](https://pandoc.org/)'s [`--slide-level` option](https://pandoc.org/MANUAL.html#structuring-the-slide-show) and [Deckset 2](https://www.deckset.com/2/)'s "Slide Dividers" option.
+
+By using `headingDivider` global directive, you can instruct to divide slide pages automatically at before of headings whose larger than or equal to specified level.
+
+For example, the below 2 markdowns have the same output.
+
+<table>
+<thead>
+<tr>
+<th style="text-align:center;">Regular syntax</th>
+<th style="text-align:center;">Heading divider</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+```markdown
+# 1st page
+
+The content of 1st page
+
+---
+
+## 2nd page
+
+### The content of 2nd page
+
+Hello, world!
+```
+
+</td><td>
+
+```markdown
+<!-- headingDivider: 2 -->
+
+# 1st page
+
+The content of 1st page
+
+## 2nd page
+
+### The content of 2nd page
+
+Hello, world!
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+It is useful when you want to create a slide deck from a plain Markdown. Even if you opened an above example of `headingDivider` in general Markdown editor, it keeps a beautiful rendering without the obtrusive horizontal rulers.
+
 ### Slide backgrounds
 
 We provide a background image syntax to specify slide's background through Markdown. Include `bg` to the alternate text.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ The content of 1st page
 ### The content of 2nd page
 
 Hello, world!
+
+---
+
+# 3rd page
+
+😃
 ```
 
 </td><td>
@@ -168,6 +174,10 @@ The content of 1st page
 ### The content of 2nd page
 
 Hello, world!
+
+# 3rd page
+
+😃
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ footer: "![image](https://example.com/image.jpg)"
 
 > :information_source: Due to the parsing order of Markdown, you cannot use [slide background images](#slide-background) in `header` and `footer` directives.
 
-#### [PLANNING] Heading divider
+#### Heading divider
 
 This feature is similar to [Pandoc](https://pandoc.org/)'s [`--slide-level` option](https://pandoc.org/MANUAL.html#structuring-the-slide-show) and [Deckset 2](https://www.deckset.com/2/)'s "Slide Dividers" option.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Hello, world!
 </tbody>
 </table>
 
-It is useful when you want to create a slide deck from a plain Markdown. Even if you opened an above example of `headingDivider` in general Markdown editor, it keeps a beautiful rendering without the obtrusive horizontal rulers.
+It is useful when you want to create a slide deck from a plain Markdown. Even if you opened an example about `headingDivider` in general Markdown editor, it keeps a beautiful rendering without horizontal rulers.
 
 ### Slide backgrounds
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,12 +3,15 @@ declare module '@marp-team/marpit' {
     backgroundSyntax?: boolean
     container?: Element | Element[]
     filters?: boolean
+    headingDivider?: false | MarpitHeadingDivider | MarpitHeadingDivider[]
     inlineStyle?: boolean
     markdown?: string | object | [string, object]
     printable?: boolean
     slideContainer?: Element | Element[]
     inlineSVG?: boolean
   }
+
+  type MarpitHeadingDivider = 1 | 2 | 3 | 4 | 5 | 6
 
   type MarpitRenderResult = {
     html: string

--- a/src/helpers/parse_yaml.js
+++ b/src/helpers/parse_yaml.js
@@ -1,0 +1,21 @@
+/** @module */
+import YAML, { FAILSAFE_SCHEMA } from 'js-yaml'
+
+/**
+ * Parse text as YAML by using js-yaml's FAILSAFE_SCHEMA.
+ *
+ * @alias module:helpers/parse_yaml
+ * @param {String} text Target text.
+ */
+function parseYAML(text) {
+  try {
+    const obj = YAML.safeLoad(text, { schema: FAILSAFE_SCHEMA })
+    if (obj === null || typeof obj !== 'object') return false
+
+    return obj
+  } catch (e) {
+    return false
+  }
+}
+
+export default parseYAML

--- a/src/markdown/comment.js
+++ b/src/markdown/comment.js
@@ -1,4 +1,6 @@
 /** @module */
+import parseYAML from '../helpers/parse_yaml'
+
 const commentMatcher = /<!--+\s*([\s\S]*?)\s*--+>/
 const commentMatcherOpening = /^<!--/
 const commentMatcherClosing = /-->/
@@ -57,6 +59,10 @@ function comment(md) {
 
       const matchedContent = commentMatcher.exec(token.markup)
       token.content = matchedContent ? matchedContent[1].trim() : ''
+
+      // Parse YAML
+      const yaml = parseYAML(token.content)
+      token.meta = { marpitParsedYAML: yaml === false ? {} : yaml }
 
       return true
     }

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -26,13 +26,19 @@
 export const globals = {
   headingDivider(value) {
     const headings = [1, 2, 3, 4, 5, 6]
-    const converted = Number.isNaN(value) ? value : Number.parseInt(value, 10)
+    const toInt = v =>
+      Array.isArray(v) || Number.isNaN(v) ? v : Number.parseInt(v, 10)
+    const converted = toInt(value)
 
-    if (Array.isArray(converted))
-      return { headingDivider: headings.filter(v => converted.includes(v)) }
+    if (Array.isArray(converted)) {
+      const convertedArr = converted.map(toInt)
+      return {
+        headingDivider: headings.filter(v => convertedArr.includes(v)),
+      }
+    }
 
-    if (headings.includes(converted) || converted === false)
-      return { headingDivider: converted }
+    if (value === 'false') return { headingDivider: false }
+    if (headings.includes(converted)) return { headingDivider: converted }
 
     return {}
   },

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -19,10 +19,23 @@
  * You can use prefix `$` as the name of a directive for the clarity (or
  * compatibility with the old version of Marp).
  *
+ * @prop {Directive} headingDivider Specify heading divider option.
  * @prop {Directive} style Specify the CSS style to apply additionally.
  * @prop {Directive} theme Specify theme of the slide deck.
  */
 export const globals = {
+  headingDivider(value) {
+    const headings = [1, 2, 3, 4, 5, 6]
+    const converted = Number.isNaN(value) ? value : Number.parseInt(value, 10)
+
+    if (Array.isArray(converted))
+      return { headingDivider: headings.filter(v => converted.includes(v)) }
+
+    if (headings.includes(converted) || converted === false)
+      return { headingDivider: converted }
+
+    return {}
+  },
   style(value) {
     return { style: value }
   },

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -16,6 +16,15 @@ function headingDivider(md, marpit) {
   md.core.ruler.before('marpit_slide', 'marpit_heading_divider', state => {
     let target = marpit.options.headingDivider
 
+    if (
+      marpit.lastGlobalDirectives &&
+      Object.prototype.hasOwnProperty.call(
+        marpit.lastGlobalDirectives,
+        'headingDivider'
+      )
+    )
+      target = marpit.lastGlobalDirectives.headingDivider
+
     if (state.inlineMode || target === false) return
 
     if (Number.isInteger(target) && target >= 1 && target <= 6)

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -1,0 +1,20 @@
+/** @module */
+
+/**
+ * Marpit heading divider plugin.
+ *
+ * Start a new slide page at before of headings.
+ *
+ * @alias module:markdown/heading_divider
+ * @param {MarkdownIt} md markdown-it instance.
+ * @param {Marpit} marpit Marpit instance.
+ */
+function headingDivider(md, marpit) {
+  md.core.ruler.before('marpit_slide', 'marpit_heading_divider', state => {
+    if (state.inlineMode || marpit.options.headingDivider === false) return
+
+    // TODO: Prepend hidden ruler token at before headings
+  })
+}
+
+export default headingDivider

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -1,4 +1,5 @@
 /** @module */
+import split from '../helpers/split'
 
 /**
  * Marpit heading divider plugin.
@@ -11,9 +12,28 @@
  */
 function headingDivider(md, marpit) {
   md.core.ruler.before('marpit_slide', 'marpit_heading_divider', state => {
-    if (state.inlineMode || marpit.options.headingDivider === false) return
+    let target = marpit.options.headingDivider
 
-    // TODO: Prepend hidden ruler token at before headings
+    if (state.inlineMode || target === false) return
+
+    if (Number.isInteger(target) && target >= 1 && target <= 6)
+      target = [...Array(headingDivider).keys()].map(i => i + 1)
+
+    if (!Array.isArray(target))
+      throw new Error('Invalid headingDivider option.')
+
+    const splitTag = target.map(i => `h${i}`)
+
+    state.tokens = split(
+      state.tokens,
+      t => t.type === 'heading_open' && splitTag.includes(t.tag),
+      true
+    ).reduce((arr, slideTokens) => {
+      // TODO: Prepend hidden ruler token at before headings
+      const isHeading = slideTokens[0] && slideTokens[0].type === 'heading_open'
+
+      return [...arr, ...slideTokens]
+    }, [])
   })
 }
 

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -30,8 +30,7 @@ function headingDivider(md, marpit) {
     if (Number.isInteger(target) && target >= 1 && target <= 6)
       target = [...Array(target).keys()].map(i => i + 1)
 
-    if (!Array.isArray(target))
-      throw new Error('Invalid headingDivider option.')
+    if (!Array.isArray(target)) return
 
     const splitTag = target.map(i => `h${i}`)
     const splitFunc = t => t.type === 'heading_open' && splitTag.includes(t.tag)

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -7,6 +7,7 @@ import marpitBackgroundImage from './markdown/background_image'
 import marpitComment from './markdown/comment'
 import marpitContainerPlugin from './markdown/container'
 import marpitHeaderAndFooter from './markdown/header_and_footer'
+import marpitHeadingDivider from './markdown/heading_divider'
 import marpitInlineSVG from './markdown/inline_svg'
 import marpitParseDirectives from './markdown/directives/parse'
 import marpitParseImage from './markdown/parse_image'
@@ -21,6 +22,7 @@ const defaultOptions = {
   backgroundSyntax: true,
   container: marpitContainer,
   filters: true,
+  headingDivider: false,
   inlineStyle: true,
   markdown: 'commonmark',
   printable: true,
@@ -45,8 +47,10 @@ class Marpit {
    *     element(s) wrapping whole slide deck.
    * @param {boolean} [opts.filters=true] Support filter syntax for markdown
    *     image. It can apply to inline image and the advanced backgrounds.
-   * @param {false|number} [opts.headingDivider=false] Start a new slide page at
-   *     before of heading whose larger than or equal to specified level.
+   * @param {false|number|number[]} [opts.headingDivider=false] Start a new
+   *     slide page at before of headings. it would apply to headings whose
+   *     larger than or equal to the specified level if a number is given, or
+   *     ONLY specified levels if a number array.
    * @param {boolean} [opts.inlineStyle=true] Recognize `<style>` elements to
    *     append additional styles to theme. When it is `true`, Marpit will parse
    *     style regardless markdown-it's `html` option.
@@ -98,6 +102,7 @@ class Marpit {
       .use(marpitParseDirectives, this)
       .use(marpitApplyDirectives)
       .use(marpitHeaderAndFooter)
+      .use(marpitHeadingDivider, this)
       .use(marpitSlideContainer, this.slideContainers)
       .use(marpitContainerPlugin, this.containers)
       .use(marpitParseImage, { filters: this.options.filters })

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -45,6 +45,8 @@ class Marpit {
    *     element(s) wrapping whole slide deck.
    * @param {boolean} [opts.filters=true] Support filter syntax for markdown
    *     image. It can apply to inline image and the advanced backgrounds.
+   * @param {false|number} [opts.headingDivider=false] Start a new slide page at
+   *     before of heading whose larger than or equal to specified level.
    * @param {boolean} [opts.inlineStyle=true] Recognize `<style>` elements to
    *     append additional styles to theme. When it is `true`, Marpit will parse
    *     style regardless markdown-it's `html` option.

--- a/test/markdown/heading_divider.js
+++ b/test/markdown/heading_divider.js
@@ -1,18 +1,15 @@
 import assert from 'assert'
 import cheerio from 'cheerio'
 import MarkdownIt from 'markdown-it'
+import comment from '../../src/markdown/comment'
 import headingDivider from '../../src/markdown/heading_divider'
+import parseDirectives from '../../src/markdown/directives/parse'
 import slide from '../../src/markdown/slide'
 
 describe('Marpit heading divider plugin', () => {
   const marpitStub = headingDividerOption => ({
     options: { headingDivider: headingDividerOption },
   })
-
-  const md = marpitInstance =>
-    new MarkdownIt('commonmark')
-      .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))
-      .use(headingDivider, marpitInstance)
 
   const markdownText = '# 1st\n## 2nd\n### 3rd\n#### 4th'
 
@@ -21,80 +18,162 @@ describe('Marpit heading divider plugin', () => {
       (t, idx) => t.type === 'hr' || (idx > 0 && tokens[idx - 1].type === 'hr')
     )
 
-  context('with headingDivider option as false', () => {
-    const markdown = md(marpitStub(false))
+  describe('Constructor option', () => {
+    const md = marpitInstance =>
+      new MarkdownIt('commonmark')
+        .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))
+        .use(headingDivider, marpitInstance)
 
-    it('does not add any horizontal ruler tokens', () => {
-      const tokens = markdown.parse(markdownText)
-      assert(tokens.filter(t => t.type === 'hr').length === 0)
+    context('with headingDivider option as false', () => {
+      const markdown = md(marpitStub(false))
+
+      it('does not add any horizontal ruler tokens', () => {
+        const tokens = markdown.parse(markdownText)
+        assert(tokens.filter(t => t.type === 'hr').length === 0)
+      })
+    })
+
+    context('with headingDivider option as 3', () => {
+      const markdown = md(marpitStub(3))
+
+      it('adds hidden hr token to before until 3rd level headings except first', () => {
+        const tokens = markdown.parse(markdownText)
+        assert(tokens.filter(t => t.type === 'hr').length === 2)
+
+        const hrAndHeadings = pickHrAndHeading(tokens)
+        assert(hrAndHeadings[0].type === 'hr')
+        assert(hrAndHeadings[0].hidden)
+        assert(hrAndHeadings[1].type === 'heading_open')
+        assert(hrAndHeadings[1].tag === 'h2')
+        assert(hrAndHeadings[2].type === 'hr')
+        assert(hrAndHeadings[2].hidden)
+        assert(hrAndHeadings[3].type === 'heading_open')
+        assert(hrAndHeadings[3].tag === 'h3')
+      })
+    })
+
+    context('with headingDivider option as array contained 3', () => {
+      const markdown = md(marpitStub([3]))
+
+      it('adds hidden hr token to before 3rd level heading', () => {
+        const tokens = markdown.parse(markdownText)
+        assert(tokens.filter(t => t.type === 'hr').length === 1)
+
+        const hrAndHeadings = pickHrAndHeading(tokens)
+        assert(hrAndHeadings[0].type === 'hr')
+        assert(hrAndHeadings[0].hidden)
+        assert(hrAndHeadings[1].type === 'heading_open')
+        assert(hrAndHeadings[1].tag === 'h3')
+      })
+    })
+
+    context('with headingDivider option as array contained 2 and 4', () => {
+      const markdown = md(marpitStub([2, 4]))
+
+      it('adds hidden hr token to before 2nd and 4th level heading', () => {
+        const tokens = markdown.parse(markdownText)
+        assert(tokens.filter(t => t.type === 'hr').length === 2)
+
+        const hrAndHeadings = pickHrAndHeading(tokens)
+        assert(hrAndHeadings[0].type === 'hr')
+        assert(hrAndHeadings[0].hidden)
+        assert(hrAndHeadings[1].type === 'heading_open')
+        assert(hrAndHeadings[1].tag === 'h2')
+        assert(hrAndHeadings[2].type === 'hr')
+        assert(hrAndHeadings[2].hidden)
+        assert(hrAndHeadings[3].type === 'heading_open')
+        assert(hrAndHeadings[3].tag === 'h4')
+      })
+    })
+
+    context('with headingDivider option as 4 and slide plugin', () => {
+      const mdWithSlide = instance =>
+        new MarkdownIt('commonmark').use(slide).use(headingDivider, instance)
+
+      it('renders four <section> elements', () => {
+        const $ = cheerio.load(mdWithSlide(marpitStub(4)).render(markdownText))
+        assert($('section').length === 4)
+      })
+    })
+
+    context('with invalid headingDivider option', () => {
+      const markdown = md(marpitStub('invalid'))
+
+      it('does not add any horizontal ruler tokens', () => {
+        const tokens = markdown.parse(markdownText)
+        assert(tokens.filter(t => t.type === 'hr').length === 0)
+      })
     })
   })
 
-  context('with headingDivider option as 3', () => {
-    const markdown = md(marpitStub(3))
+  describe('Global directive', () => {
+    const md = (marpitInstance = { options: {} }) =>
+      new MarkdownIt('commonmark')
+        .use(comment)
+        .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))
+        .use(parseDirectives, marpitInstance)
+        .use(headingDivider, marpitInstance)
 
-    it('adds hidden hr token to before until 3rd level headings except first', () => {
-      const tokens = markdown.parse(markdownText)
-      assert(tokens.filter(t => t.type === 'hr').length === 2)
+    const markdownTextWithDirective = level =>
+      `---\nheadingDivider: ${level}\n---\n\n${markdownText}`
 
-      const hrAndHeadings = pickHrAndHeading(tokens)
-      assert(hrAndHeadings[0].type === 'hr')
-      assert(hrAndHeadings[0].hidden)
-      assert(hrAndHeadings[1].type === 'heading_open')
-      assert(hrAndHeadings[1].tag === 'h2')
-      assert(hrAndHeadings[2].type === 'hr')
-      assert(hrAndHeadings[2].hidden)
-      assert(hrAndHeadings[3].type === 'heading_open')
-      assert(hrAndHeadings[3].tag === 'h3')
+    const markdownTextWithComment = level =>
+      `${markdownText}\n<!-- headingDivider: ${level} -->`
+
+    context('with headingDivider directive as 3', () => {
+      const markdown = md()
+      const text = markdownTextWithDirective(3)
+
+      it('adds hidden hr token to before until 3rd level headings except first', () => {
+        const tokens = markdown.parse(text)
+        assert(tokens.filter(t => t.type === 'hr').length === 2)
+
+        const hrAndHeadings = pickHrAndHeading(tokens)
+        assert(hrAndHeadings[0].type === 'hr')
+        assert(hrAndHeadings[0].hidden)
+        assert(hrAndHeadings[1].type === 'heading_open')
+        assert(hrAndHeadings[1].tag === 'h2')
+        assert(hrAndHeadings[2].type === 'hr')
+        assert(hrAndHeadings[2].hidden)
+        assert(hrAndHeadings[3].type === 'heading_open')
+        assert(hrAndHeadings[3].tag === 'h3')
+      })
     })
-  })
 
-  context('with headingDivider option as array contained 3', () => {
-    const markdown = md(marpitStub([3]))
+    context(
+      'with headingDivider directive with comment as array contained 2 and 4',
+      () => {
+        const markdown = md()
+        const text = markdownTextWithComment('[2,4]')
 
-    it('adds hidden hr token to before 3rd level heading', () => {
-      const tokens = markdown.parse(markdownText)
-      assert(tokens.filter(t => t.type === 'hr').length === 1)
+        it('adds hidden hr token to before 2nd and 4th level heading', () => {
+          const tokens = markdown.parse(text)
+          assert(tokens.filter(t => t.type === 'hr').length === 2)
 
-      const hrAndHeadings = pickHrAndHeading(tokens)
-      assert(hrAndHeadings[0].type === 'hr')
-      assert(hrAndHeadings[0].hidden)
-      assert(hrAndHeadings[1].type === 'heading_open')
-      assert(hrAndHeadings[1].tag === 'h3')
+          const hrAndHeadings = pickHrAndHeading(tokens)
+          assert(hrAndHeadings[0].type === 'hr')
+          assert(hrAndHeadings[0].hidden)
+          assert(hrAndHeadings[1].type === 'heading_open')
+          assert(hrAndHeadings[1].tag === 'h2')
+          assert(hrAndHeadings[2].type === 'hr')
+          assert(hrAndHeadings[2].hidden)
+          assert(hrAndHeadings[3].type === 'heading_open')
+          assert(hrAndHeadings[3].tag === 'h4')
+        })
+      }
+    )
+
+    context('with headingDivider option and directive', () => {
+      const markdown = md(marpitStub(4))
+      const text = markdownTextWithDirective('false')
+
+      it('overrides headingDivider option by directive', () => {
+        const tokens = markdown.parse(markdownText)
+        assert(tokens.filter(t => t.type === 'hr').length === 3)
+
+        const tokensWithOverride = markdown.parse(text)
+        assert(tokensWithOverride.filter(t => t.type === 'hr').length === 0)
+      })
     })
-  })
-
-  context('with headingDivider option as array contained 2 and 4', () => {
-    const markdown = md(marpitStub([2, 4]))
-
-    it('adds hidden hr token to before 2nd and 4th level heading', () => {
-      const tokens = markdown.parse(markdownText)
-      assert(tokens.filter(t => t.type === 'hr').length === 2)
-
-      const hrAndHeadings = pickHrAndHeading(tokens)
-      assert(hrAndHeadings[0].type === 'hr')
-      assert(hrAndHeadings[0].hidden)
-      assert(hrAndHeadings[1].type === 'heading_open')
-      assert(hrAndHeadings[1].tag === 'h2')
-      assert(hrAndHeadings[2].type === 'hr')
-      assert(hrAndHeadings[2].hidden)
-      assert(hrAndHeadings[3].type === 'heading_open')
-      assert(hrAndHeadings[3].tag === 'h4')
-    })
-  })
-
-  context('with headingDivider option as 4 and slide plugin', () => {
-    const mdWithSlide = instance =>
-      new MarkdownIt('commonmark').use(slide).use(headingDivider, instance)
-
-    it('renders four <section> elements', () => {
-      const $ = cheerio.load(mdWithSlide(marpitStub(4)).render(markdownText))
-      assert($('section').length === 4)
-    })
-  })
-
-  context('with invalid headingDivider option', () => {
-    const markdown = md(marpitStub('invalid'))
-    it('throws error', () => assert.throws(() => markdown.parse(markdownText)))
   })
 })

--- a/test/markdown/heading_divider.js
+++ b/test/markdown/heading_divider.js
@@ -163,16 +163,20 @@ describe('Marpit heading divider plugin', () => {
       }
     )
 
-    context('with headingDivider option and directive', () => {
+    context('with headingDivider constructor option', () => {
       const markdown = md(marpitStub(4))
-      const text = markdownTextWithDirective('false')
 
       it('overrides headingDivider option by directive', () => {
         const tokens = markdown.parse(markdownText)
         assert(tokens.filter(t => t.type === 'hr').length === 3)
 
-        const tokensWithOverride = markdown.parse(text)
-        assert(tokensWithOverride.filter(t => t.type === 'hr').length === 0)
+        const overridden = markdown.parse(markdownTextWithDirective('false'))
+        assert(overridden.filter(t => t.type === 'hr').length === 0)
+      })
+
+      it('ignores invalid headingDivider directive', () => {
+        const overridden = markdown.parse(markdownTextWithDirective('invalid'))
+        assert(overridden.filter(t => t.type === 'hr').length === 3)
       })
     })
   })

--- a/test/markdown/heading_divider.js
+++ b/test/markdown/heading_divider.js
@@ -1,6 +1,8 @@
 import assert from 'assert'
+import cheerio from 'cheerio'
 import MarkdownIt from 'markdown-it'
 import headingDivider from '../../src/markdown/heading_divider'
+import slide from '../../src/markdown/slide'
 
 describe('Marpit heading divider plugin', () => {
   const marpitStub = headingDividerOption => ({
@@ -14,6 +16,11 @@ describe('Marpit heading divider plugin', () => {
 
   const markdownText = '# 1st\n## 2nd\n### 3rd\n#### 4th'
 
+  const pickHrAndHeading = tokens =>
+    tokens.filter(
+      (t, idx) => t.type === 'hr' || (idx > 0 && tokens[idx - 1].type === 'hr')
+    )
+
   context('with headingDivider option as false', () => {
     const markdown = md(marpitStub(false))
 
@@ -23,19 +30,71 @@ describe('Marpit heading divider plugin', () => {
     })
   })
 
-  context('with headingDivider option as array contained "3"', () => {
+  context('with headingDivider option as 3', () => {
+    const markdown = md(marpitStub(3))
+
+    it('adds hidden hr token to before until 3rd level headings except first', () => {
+      const tokens = markdown.parse(markdownText)
+      assert(tokens.filter(t => t.type === 'hr').length === 2)
+
+      const hrAndHeadings = pickHrAndHeading(tokens)
+      assert(hrAndHeadings[0].type === 'hr')
+      assert(hrAndHeadings[0].hidden)
+      assert(hrAndHeadings[1].type === 'heading_open')
+      assert(hrAndHeadings[1].tag === 'h2')
+      assert(hrAndHeadings[2].type === 'hr')
+      assert(hrAndHeadings[2].hidden)
+      assert(hrAndHeadings[3].type === 'heading_open')
+      assert(hrAndHeadings[3].tag === 'h3')
+    })
+  })
+
+  context('with headingDivider option as array contained 3', () => {
     const markdown = md(marpitStub([3]))
 
-    it('adds hidden horizontal ruler to before 3rd level heading', () => {
+    it('adds hidden hr token to before 3rd level heading', () => {
       const tokens = markdown.parse(markdownText)
-      const filtered = tokens.filter(
-        (t, idx) =>
-          t.type === 'hr' || (idx > 0 && tokens[idx - 1].type === 'hr')
-      )
-
       assert(tokens.filter(t => t.type === 'hr').length === 1)
-      assert(filtered[1].type === 'heading_open')
-      assert(filtered[1].tag === 'h3')
+
+      const hrAndHeadings = pickHrAndHeading(tokens)
+      assert(hrAndHeadings[0].type === 'hr')
+      assert(hrAndHeadings[0].hidden)
+      assert(hrAndHeadings[1].type === 'heading_open')
+      assert(hrAndHeadings[1].tag === 'h3')
     })
+  })
+
+  context('with headingDivider option as array contained 2 and 4', () => {
+    const markdown = md(marpitStub([2, 4]))
+
+    it('adds hidden hr token to before 2nd and 4th level heading', () => {
+      const tokens = markdown.parse(markdownText)
+      assert(tokens.filter(t => t.type === 'hr').length === 2)
+
+      const hrAndHeadings = pickHrAndHeading(tokens)
+      assert(hrAndHeadings[0].type === 'hr')
+      assert(hrAndHeadings[0].hidden)
+      assert(hrAndHeadings[1].type === 'heading_open')
+      assert(hrAndHeadings[1].tag === 'h2')
+      assert(hrAndHeadings[2].type === 'hr')
+      assert(hrAndHeadings[2].hidden)
+      assert(hrAndHeadings[3].type === 'heading_open')
+      assert(hrAndHeadings[3].tag === 'h4')
+    })
+  })
+
+  context('with headingDivider option as 4 and slide plugin', () => {
+    const mdWithSlide = instance =>
+      new MarkdownIt('commonmark').use(slide).use(headingDivider, instance)
+
+    it('renders four <section> elements', () => {
+      const $ = cheerio.load(mdWithSlide(marpitStub(4)).render(markdownText))
+      assert($('section').length === 4)
+    })
+  })
+
+  context('with invalid headingDivider option', () => {
+    const markdown = md(marpitStub('invalid'))
+    it('throws error', () => assert.throws(() => markdown.parse(markdownText)))
   })
 })

--- a/test/markdown/heading_divider.js
+++ b/test/markdown/heading_divider.js
@@ -1,0 +1,41 @@
+import assert from 'assert'
+import MarkdownIt from 'markdown-it'
+import headingDivider from '../../src/markdown/heading_divider'
+
+describe('Marpit heading divider plugin', () => {
+  const marpitStub = headingDividerOption => ({
+    options: { headingDivider: headingDividerOption },
+  })
+
+  const md = marpitInstance =>
+    new MarkdownIt('commonmark')
+      .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))
+      .use(headingDivider, marpitInstance)
+
+  const markdownText = '# 1st\n## 2nd\n### 3rd\n#### 4th'
+
+  context('with headingDivider option as false', () => {
+    const markdown = md(marpitStub(false))
+
+    it('does not add any horizontal ruler tokens', () => {
+      const tokens = markdown.parse(markdownText)
+      assert(tokens.filter(t => t.type === 'hr').length === 0)
+    })
+  })
+
+  context('with headingDivider option as array contained "3"', () => {
+    const markdown = md(marpitStub([3]))
+
+    it('adds hidden horizontal ruler to before 3rd level heading', () => {
+      const tokens = markdown.parse(markdownText)
+      const filtered = tokens.filter(
+        (t, idx) =>
+          t.type === 'hr' || (idx > 0 && tokens[idx - 1].type === 'hr')
+      )
+
+      assert(tokens.filter(t => t.type === 'hr').length === 1)
+      assert(filtered[1].type === 'heading_open')
+      assert(filtered[1].tag === 'h3')
+    })
+  })
+})


### PR DESCRIPTION
This PR will add a `headingDivider` global directive to support starting a new slide page at before of headings whose specified (or larger) level.

It also will support `headingDivider` constructor option of `Marpit` class. Marpit heading divider plugin will prepend hidden `---` before targeted headings. The slide plugin also would recognize these rulers for dividing into slide pages.

This feature is similar to [Pandoc](https://pandoc.org/)'s [`--slide-level` option](https://pandoc.org/MANUAL.html#structuring-the-slide-show) and [Deckset 2](https://www.deckset.com/2/)'s "Slide Dividers" option. It would be useful when creating a slide deck from plain Markdown.