### PR TITLE
Mark Marpit's options member as immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Migrate test framework from mocha to jest ([#43](https://github.com/marp-team/marpit/pull/43))
 - Migrate CI from Travis CI to CircleCI ([#44](https://github.com/marp-team/marpit/pull/44))
+- Mark Marpit's `options` property as immutable ([#46](https://github.com/marp-team/marpit/pull/46))
 
 ## v0.0.9 - 2018-07-23
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ declare module '@marp-team/marpit' {
     markdown: any
     themeSet: ThemeSet
 
+    readonly options: MarpitOptions
     readonly markdownItPlugins: (md: any) => void
 
     render(markdown: string): MarpitRenderResult

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -63,7 +63,20 @@ class Marpit {
    *     _(Experimental)_
    */
   constructor(opts = {}) {
-    this.options = { ...defaultOptions, ...opts }
+    /**
+     * The current options for this instance.
+     *
+     * This property is read-only and marked as immutable. You cannot change the
+     * value of options after creating instance.
+     *
+     * @member {Object} options
+     * @memberOf Marpit#
+     * @readonly
+     */
+    Object.defineProperty(this, 'options', {
+      enumerable: true,
+      value: Object.freeze({ ...defaultOptions, ...opts }),
+    })
 
     Object.defineProperties(this, {
       containers: { value: [...wrapArray(this.options.container)] },

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -21,6 +21,16 @@ describe('Marpit', () => {
       expect(instance.options.inlineSVG).toBe(false)
     })
 
+    it('marks options property as immutable', () => {
+      expect(() => {
+        instance.options = { updated: true }
+      }).toThrow(TypeError)
+
+      expect(() => {
+        instance.options.printable = false
+      }).not.toThrow(TypeError)
+    })
+
     it('has themeSet property', () => {
       expect(instance.themeSet).toBeInstanceOf(ThemeSet)
       expect(instance.themeSet.size).toBe(0)

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -28,7 +28,7 @@ describe('Marpit', () => {
 
       expect(() => {
         instance.options.printable = false
-      }).not.toThrow(TypeError)
+      }).toThrow(TypeError)
     })
 
     it('has themeSet property', () => {


### PR DESCRIPTION
We use `options` member of Marpit to store the initial options. Some several plugins have used this value directly because of supporting the change of value.

But actually, we have mixed the usage of options. For example, `backgroundSyntax` and `filter` option cannot apply the change of `options` value that makes after creating instance.

With this PR, we will mark `options` as immutable. To be specific, the `options` property of `Marpit` is defined by `Object.defineProperty()` without `writable`, and options object is frozen by `Object.freeze()`.

Also we added the JSDoc document and TypeScript definition.