### PR TITLE
Improve appending/prepending style on ThemeSet#pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- **[BREAKING]** Improve appending/prepending style on `ThemeSet#pack` ([#47](https://github.com/marp-team/marpit/pull/47))
+  - `ThemeSet#pack`'s [`appendStyle` option](https://github.com/marp-team/marpit/blob/c1fce7c7f80fb563111b8b0e34d98eabc5c834a3/src/theme_set.js#L171) is renamed to [`after`](https://github.com/marp-team/marpit/blob/e68f0bb38a6d894cce80fa811d41952635a886b6/src/theme_set.js#L172).
 - Migrate test framework from mocha to jest ([#43](https://github.com/marp-team/marpit/pull/43))
 - Migrate CI from Travis CI to CircleCI ([#44](https://github.com/marp-team/marpit/pull/44))
 - Mark Marpit's `options` property as immutable ([#46](https://github.com/marp-team/marpit/pull/46))

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,8 @@ declare module '@marp-team/marpit' {
   }
 
   type ThemeSetPackOptions = {
-    appendStyle?: string
+    after?: string
+    before?: string
     containers?: Element[]
     printable?: boolean
     inlineSVG?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ declare module '@marp-team/marpit' {
     protected applyMarkdownItPlugins(md: any): void
     protected renderMarkdown(markdown: string): string
     protected renderStyle(theme?: string): string
+    protected themeSetPackOptions(): ThemeSetPackOptions
   }
 
   export class Element {

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -163,7 +163,7 @@ class Marpit {
   /** @private */
   themeSetPackOptions() {
     return {
-      appendStyle: this.lastStyles && this.lastStyles.join('\n'),
+      after: this.lastStyles ? this.lastStyles.join('\n') : undefined,
       containers: [...this.containers, ...this.slideContainers],
       inlineSVG: this.options.inlineSVG,
       printable: this.options.printable,

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -157,12 +157,17 @@ class Marpit {
    * @returns {string} The result string of rendering style.
    */
   renderStyle(theme) {
-    return this.themeSet.pack(theme, {
+    return this.themeSet.pack(theme, this.themeSetPackOptions())
+  }
+
+  /** @private */
+  themeSetPackOptions() {
+    return {
       appendStyle: this.lastStyles && this.lastStyles.join('\n'),
       containers: [...this.containers, ...this.slideContainers],
       inlineSVG: this.options.inlineSVG,
       printable: this.options.printable,
-    })
+    }
   }
 }
 

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -9,7 +9,6 @@ import postcssPseudoPrepend from './postcss/pseudo_selector/prepend'
 import postcssPseudoReplace from './postcss/pseudo_selector/replace'
 import Theme from './theme'
 import scaffold from './theme/scaffold'
-import wrapArray from './helpers/wrap_array'
 
 /**
  * Marpit theme set class.


### PR DESCRIPTION
This PR will change the options of `ThemeSet#pack` to make consistent.

**`appendStyle` option is renamed to `after`,** and we add `before` option to prepend style before theme.

It will become a breaking change, so we write down to CHANGELOG.md about this change.

> This change will use in [`@marp-team/marp-core`'s math typesetting support](https://github.com/marp-team/marp-core/compare/math-typesetting).
>
> This PR includes the improvement of `Marp`'s internal method `#renderStyle` to split options into `#themeSetPackOptions`. It could customize packing option on extended class easily.