### PR TITLE
Bugfix: Pass class attribute to pseudo section on advanced background 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Bugfix: Pass `class` attribute to pseudo section on advanced background ([#48](https://github.com/marp-team/marpit/pull/48))
+
 ## v0.0.10 - 2018-08-05
 
 - **[BREAKING]** Improve appending/prepending style on `ThemeSet#pack` ([#47](https://github.com/marp-team/marpit/pull/47))

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -214,6 +214,7 @@ function backgroundImage(md) {
               },
               wrapTokens('marpit_advanced_pseudo_section', {
                 tag: 'section',
+                class: open.attrGet('class'),
                 style: style.toString(),
                 'data-marpit-advanced-background': 'pseudo',
                 'data-marpit-pagination': open.attrGet(

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -299,8 +299,12 @@ describe('Marpit background image plugin', () => {
       })
     })
 
-    context('with paginate directive', () => {
-      const $ = $load(mdSVG().render('<!-- paginate: true -->\n\n![bg](test)'))
+    context('with paginate and class directive', () => {
+      const $ = $load(
+        mdSVG().render(
+          '---\npaginate: true\nclass: pseudo layer\n---\n\n![bg](test)'
+        )
+      )
 
       it('assigns data-marpit-pagination attribute to pseudo layer', () => {
         const foreignObjects = $('svg > foreignObject')
@@ -312,7 +316,9 @@ describe('Marpit background image plugin', () => {
         )
 
         expect(
-          pseudoFO.find('> section').is('[data-marpit-pagination="1"]')
+          pseudoFO
+            .find('> section.pseudo.layer')
+            .is('[data-marpit-pagination="1"]')
         ).toBe(true)
       })
     })


### PR DESCRIPTION
If you are using Marpit with inline SVG mode (`inlineSVG: true`), Marpit makes a layer to show `section::after` pseudo-element for the pagination, that is not affected changing layout by split backgrounds.

When you use `paginate` directive together with `class` directive, the created layer has not inherited section's class.

```markdown
---
paginate: true
class: red
---

<style>
section.red::after {
  color: red;
}
</style>

This page will be colored page number to red in inline SVG mode.

---

![bg left 80%](https://raw.githubusercontent.com/yhatt/marp/master/images/marp.png)

But this page *won't* be colored page number to red in inline SVG mode.
```

The result of rendering is [here (PDF)](https://github.com/marp-team/marpit/files/2268540/pseudo-layer.pdf).

This PR will fix this behavior by passing `class` attribute to `<section>` on pseudo-layer.
