### PR TITLE
Support class directive defined by array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Pass `class` attribute to pseudo section on advanced background ([#48](https://github.com/marp-team/marpit/pull/48))
 - Lazy yaml support by `lazyYAML` option ([#49](https://github.com/marp-team/marpit/pull/49))
 - Migrate coverage report service from [Coveralls](https://coveralls.io/github/marp-team/marpit?branch=master) to [Codecov](https://codecov.io/gh/marp-team/marpit) ([#50](https://github.com/marp-team/marpit/pull/50))
+- Support `class` directive defined by array ([#51](https://github.com/marp-team/marpit/pull/51))
 
 ## v0.0.10 - 2018-08-05
 

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -93,7 +93,7 @@ export const locals = {
     return { backgroundSize: value }
   },
   class(value) {
-    return { class: value }
+    return { class: Array.isArray(value) ? value.join(' ') : value }
   },
   color(value) {
     return { color: value }

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -129,5 +129,28 @@ describe('Marpit directives parse plugin', () => {
         })
       }
     )
+
+    context('with class directive', () => {
+      const expected = { class: 'one two three' }
+
+      it('supports class definition by array', () => {
+        const flatParsed = md().parse('<!-- class: ["one", "two", "three"] -->')
+        const [flatOpen] = flatParsed.filter(
+          t => t.type === 'marpit_slide_open'
+        )
+        expect(flatOpen.meta.marpitDirectives).toMatchObject(expected)
+
+        const multilineParsed = md().parse(dedent`
+          class:
+            - one
+            - two
+            - three
+        `)
+        const [multilineOpen] = multilineParsed.filter(
+          t => t.type === 'marpit_slide_open'
+        )
+        expect(multilineOpen.meta.marpitDirectives).toMatchObject(expected)
+      })
+    })
   })
 })

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -141,10 +141,12 @@ describe('Marpit directives parse plugin', () => {
         expect(flatOpen.meta.marpitDirectives).toMatchObject(expected)
 
         const multilineParsed = md().parse(dedent`
+          ---
           class:
             - one
             - two
             - three
+          ---
         `)
         const [multilineOpen] = multilineParsed.filter(
           t => t.type === 'marpit_slide_open'


### PR DESCRIPTION
This PR will support `class` directive defined by array.

```markdown
---
theme: gaia
class:
  - gaia
  - lead
---

# Array `class` directive
```

