### PR TITLE
Parse inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Lazy yaml support by `lazyYAML` option ([#49](https://github.com/marp-team/marpit/pull/49))
 - Migrate coverage report service from [Coveralls](https://coveralls.io/github/marp-team/marpit?branch=master) to [Codecov](https://codecov.io/gh/marp-team/marpit) ([#50](https://github.com/marp-team/marpit/pull/50))
 - Support `class` directive defined by array ([#51](https://github.com/marp-team/marpit/pull/51))
+- Parse inline comment ([#52](https://github.com/marp-team/marpit/pull/52))
 
 ## v0.0.10 - 2018-08-05
 

--- a/test/markdown/comment.js
+++ b/test/markdown/comment.js
@@ -46,14 +46,11 @@ describe('Marpit comment plugin', () => {
 
         expect(comments).toContain('comment!')
         expect(comments).toContain('supports\nmultiline')
-
-        // TODO: Supports inline comment
-        // expect(comments).toContain('inline')
-        // expect(comments).toContain('comment in header')
+        expect(comments).toContain('inline')
+        expect(comments).toContain('comment in header')
       })
 
-      // TODO: Supports inline comment
-      it.skip('strips comment in rendering', () => {
+      it('strips comment in rendering', () => {
         const $ = cheerio.load(markdown.render(text))
         const comments = extractComments($)
 

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -57,7 +57,7 @@ describe('Marpit directives parse plugin', () => {
       const text = dedent`
         <!-- Theme accepts that only defined in Marpit#themeSet -->
         ***
-        <!-- theme: test_theme -->
+        Inline<!-- theme: test_theme -->comment
         ***
         <!-- theme: undefined_theme -->
       `


### PR DESCRIPTION
This PR will re-enable parsing inline comment. The inline comment was disabled in https://github.com/marp-team/marpit/pull/28#pullrequestreview-123572373 and it has published as [`v0.0.6`](https://github.com/marp-team/marpit/blob/master/CHANGELOG.md#v006---2018-05-29).

It will detect the directive comment while string even if markdown-it's `html` option as `false`.

```
## Allow directive comment <!-- color: red --> while inline text.
```

![](https://user-images.githubusercontent.com/3993388/44003936-cb8d3198-9e95-11e8-8fec-359db76a8207.png)
