### PR TITLE
Improve type definition about slide containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Improve type definition about slide containers ([#56](https://github.com/marp-team/marpit/pull/56))
+
 ## v0.0.12 - 2018-08-18
 
 - Remove Unicode Emoji support due to many issues on stable Chrome ([#53](https://github.com/marp-team/marpit/pull/53))

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
 declare module '@marp-team/marpit' {
   interface MarpitOptions {
     backgroundSyntax?: boolean
-    container?: Element | Element[]
+    container?: false | Element | Element[]
     filters?: boolean
     headingDivider?: false | MarpitHeadingDivider | MarpitHeadingDivider[]
     inlineStyle?: boolean
     lazyYAML?: boolean
     markdown?: string | object | [string, object]
     printable?: boolean
-    slideContainer?: Element | Element[]
+    slideContainer?: false | Element | Element[]
     inlineSVG?: boolean
   }
 

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -26,7 +26,7 @@ const defaultOptions = {
   lazyYAML: false,
   markdown: 'commonmark',
   printable: true,
-  slideContainer: undefined,
+  slideContainer: false,
   inlineSVG: false,
 }
 
@@ -42,7 +42,7 @@ class Marpit {
    *     with the alternate text including `bg`. Normally it converts into spot
    *     directives about background image. If `inlineSVG` is enabled, it
    *     supports the advanced backgrounds.
-   * @param {Element|Element[]}
+   * @param {false|Element|Element[]}
    *     [opts.container={@link module:element.marpitContainer}] Container
    *     element(s) wrapping whole slide deck.
    * @param {boolean} [opts.filters=true] Support filter syntax for markdown
@@ -58,7 +58,7 @@ class Marpit {
    * @param {string|Object|Array} [opts.markdown='commonmark'] markdown-it
    *     initialize option(s).
    * @param {boolean} [opts.printable=true] Make style printable to PDF.
-   * @param {Element|Element[]} [opts.slideContainer] Container element(s)
+   * @param {false|Element|Element[]} [opts.slideContainer] Container element(s)
    *     wrapping each slide sections.
    * @param {boolean} [opts.inlineSVG=false] Wrap each sections by inline SVG.
    *     _(Experimental)_

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -17,7 +17,7 @@ describe('Marpit', () => {
       expect(instance.options.backgroundSyntax).toBe(true)
       expect(instance.options.markdown).toBe('commonmark')
       expect(instance.options.printable).toBe(true)
-      expect(instance.options.slideContainer).toBeUndefined()
+      expect(instance.options.slideContainer).toBe(false)
       expect(instance.options.inlineSVG).toBe(false)
     })
 


### PR DESCRIPTION
Quoted from [README.md](https://github.com/marp-team/marpit#html-output):

> This container element(s) can change in Marpit constructor option. Also `container: false` can disable wrapping.

But we cannot set `container` (and `slideContainer`) options as `false` in TypeScript. So we allow `false` for these props in `index.d.ts`.