### PR TITLE
Support CSS scoping by element id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Improve type definition about slide containers ([#56](https://github.com/marp-team/marpit/pull/56))
+- Support CSS scoping by element id ([#57](https://github.com/marp-team/marpit/pull/57))
 
 ## v0.0.12 - 2018-08-18
 

--- a/src/postcss/pseudo_selector/replace.js
+++ b/src/postcss/pseudo_selector/replace.js
@@ -4,7 +4,14 @@ import wrapArray from '../../helpers/wrap_array'
 
 const buildSelector = elms =>
   elms
-    .map(e => [e.tag, ...(e.class || '').split(/\s+/).filter(c => c)].join('.'))
+    .map(e => {
+      const classes = new Set((e.class || '').split(/\s+/).filter(c => c))
+
+      let element = [e.tag, ...classes].join('.')
+      if (e.id) element += `#${e.id}`
+
+      return element
+    })
     .join(' > ')
 
 /**

--- a/test/postcss/pseudo_selector/replace.js
+++ b/test/postcss/pseudo_selector/replace.js
@@ -51,10 +51,9 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
       it('replaces container into an element', () => {
         const container = new Element('div')
 
-        return run(css, container).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('div > section')
-        })
+        return run(css, container).then(result =>
+          expect(result.root.first.selector).toBe('div > section')
+        )
       })
     })
 
@@ -62,21 +61,45 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
       it('replaces container into multiple elements combined by child combinator', () => {
         const containers = [new Element('div'), new Element('span')]
 
-        return run(css, containers).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('div > span > section')
-        })
+        return run(css, containers).then(result =>
+          expect(result.root.first.selector).toBe('div > span > section')
+        )
       })
     })
 
     context('when container element has specified class', () => {
-      it('replaces container into an element combined by class selectors', () => {
+      it('replaces container into an element with class selectors', () => {
         const container = new Element('div', { class: 'foo bar' })
 
-        return run(css, container).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('div.foo.bar > section')
-        })
+        return run(css, container).then(result =>
+          expect(result.root.first.selector).toBe('div.foo.bar > section')
+        )
+      })
+
+      it('removes duplicated class from selector', () => {
+        const container = new Element('div', { class: 'one two one' })
+
+        return run(css, container).then(result =>
+          expect(result.root.first.selector).toBe('div.one.two > section')
+        )
+      })
+    })
+
+    context('when container element has id', () => {
+      it('replaces container into an element with id selectors', () => {
+        const container = new Element('div', { id: 'identifier' })
+
+        return run(css, container).then(result =>
+          expect(result.root.first.selector).toBe('div#identifier > section')
+        )
+      })
+
+      it('replaces container into selector consisted by class and id', () => {
+        const container = new Element('div', { class: 'one two', id: 'id' })
+
+        return run(css, container).then(result =>
+          expect(result.root.first.selector).toBe('div.one.two#id > section')
+        )
       })
     })
   })
@@ -86,20 +109,18 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
 
     context('when slide element is null', () => {
       it('remove pseudo elements', () =>
-        run(css, undefined, null).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('h1')
-        }))
+        run(css, undefined, null).then(result =>
+          expect(result.root.first.selector).toBe('h1')
+        ))
     })
 
     context('when slide element is a single element', () => {
       it('replaces slide into an element', () => {
         const container = new Element('div')
 
-        return run(css, undefined, container).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('div h1')
-        })
+        return run(css, undefined, container).then(result =>
+          expect(result.root.first.selector).toBe('div h1')
+        )
       })
     })
 
@@ -107,21 +128,45 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
       it('replaces slide into multiple elements combined by child combinator', () => {
         const container = [new Element('svg'), new Element('foreignObject')]
 
-        return run(css, undefined, container).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('svg > foreignObject h1')
-        })
+        return run(css, undefined, container).then(result =>
+          expect(result.root.first.selector).toBe('svg > foreignObject h1')
+        )
       })
     })
 
     context('when slide element has specified class', () => {
-      it('replaces slide into an element combined by class selectors', () => {
+      it('replaces slide into an element with class selectors', () => {
         const container = new Element('div', { class: 'foo bar' })
 
-        return run(css, undefined, container).then(result => {
-          const { selector } = result.root.first
-          expect(selector).toBe('div.foo.bar h1')
-        })
+        return run(css, undefined, container).then(result =>
+          expect(result.root.first.selector).toBe('div.foo.bar h1')
+        )
+      })
+
+      it('removes duplicated class from selector', () => {
+        const container = new Element('div', { class: 'one two one' })
+
+        return run(css, undefined, container).then(result =>
+          expect(result.root.first.selector).toBe('div.one.two h1')
+        )
+      })
+    })
+
+    context('when slide element has id', () => {
+      it('replaces slide into an element with id selectors', () => {
+        const container = new Element('div', { id: 'identifier' })
+
+        return run(css, undefined, container).then(result =>
+          expect(result.root.first.selector).toBe('div#identifier h1')
+        )
+      })
+
+      it('replaces slide into selector consisted by class and id', () => {
+        const container = new Element('div', { class: 'one two', id: 'id' })
+
+        return run(css, undefined, container).then(result =>
+          expect(result.root.first.selector).toBe('div.one.two#id h1')
+        )
       })
     })
   })


### PR DESCRIPTION
This PR will support CSS scoping by element id.

On `ThemeSet#pack`, Marpit's `container` and `slideContainer` have been used to genearte a scoped CSS selector. It supports scoping by `class` attribute, but sometimes you might want higher specificity.

We will improve PostCSS pseudo selector replace plugin to recognize `id` attribute.

```javascript
const container = new Element('div', { id: 'container' })
const { css } = new Marpit({ container }).render('# Markdown')
```

```css
/* Internal pseudo selector */
:marpit-container > :marpit-slide { background: #fff; }

/* After convert */
div#container > section { background: #fff; }
```

This feature might use in [@marp-team/marp-cli](https://github.com/marp-team/marp-cli)'s bespoke template.