### PR TITLE
Improve type definition about Theme.meta and Marpit's internal variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Improve type definition about slide containers ([#56](https://github.com/marp-team/marpit/pull/56))
+- Improve type definition about slide containers, theme metas, and internal variables ([#56](https://github.com/marp-team/marpit/pull/56), [#58](https://github.com/marp-team/marpit/pull/58))
 - Support CSS scoping by element id ([#57](https://github.com/marp-team/marpit/pull/57))
 
 ## v0.0.12 - 2018-08-18

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,9 @@ declare module '@marp-team/marpit' {
     readonly options: MarpitOptions
     readonly markdownItPlugins: (md: any) => void
 
+    protected lastGlobalDirectives?: { [directive: string]: any }
+    protected lastStyles?: string[]
+
     render(markdown: string): MarpitRenderResult
 
     protected applyMarkdownItPlugins(md: any): void
@@ -62,7 +65,10 @@ declare module '@marp-team/marpit' {
       node: any
       value: string
     }[]
-    meta: {}
+    meta: {
+      theme: string
+      [key: string]: string
+    }
     name: string
     width: string
 


### PR DESCRIPTION
This PR will improve type definitions about `Theme.meta` and Marpit's internal variables. (mark as `protected`)

- `Theme` class's `meta` property had not been an indexable types. We added it and add `theme` property definition too. It is always available whenever *following this definition*.

- Add definition about frequently used internal variables in `Marpit` class. We marked these as `protected` for inherited class developer. User should not use these.