### PR TITLE
Update Marpit API URL to use own domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Update Marpit API URL to use own domains ([#59](https://github.com/marp-team/marpit/pull/59))
+
 ## v0.0.13 - 2018-08-27
 
 - Improve type definition about slide containers, theme metas, and internal variables ([#56](https://github.com/marp-team/marpit/pull/56), [#58](https://github.com/marp-team/marpit/pull/58))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 ## v0.0.2 - 2018-04-28
 
 - Support background image syntax ([#4](https://github.com/marp-team/marpit/pull/4), [#5](https://github.com/marp-team/marpit/pull/5), and [#8](https://github.com/marp-team/marpit/pull/8))
-- Add [JSDoc documentation to `ThemeSet` class methods](https://marpit.netlify.com/themeset) ([#7](https://github.com/marp-team/marpit/pull/7))
+- Add [JSDoc documentation to `ThemeSet` class methods](https://marpit-api.marp.app/themeset) ([#7](https://github.com/marp-team/marpit/pull/7))
 - Improve the sweep logic of blank paragraphs by split into another plugin ([#8](https://github.com/marp-team/marpit/pull/8))
 
 ## v0.0.1 - 2018-03-28

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ In addition, [the advanced backgrounds](#advanced-backgrounds-with-inline-svg-mo
 
 ## API
 
-Refer JSDoc: **[https://marpit.netlify.com/](https://marpit.netlify.com/)**
+Refer JSDoc: **[https://marpit-api.marp.app/](https://marpit-api.marp.app/)**
 
 ## Development
 

--- a/api.md
+++ b/api.md
@@ -1,6 +1,6 @@
-# [Marpit API](https://marpit.netlify.com/)
+# [Marpit API](https://marpit-api.marp.app/)
 
-The documentation of Marpit API on `master` branch has been published at **[https://marpit.netlify.com/](https://marpit.netlify.com/)**.
+The documentation of Marpit API on `master` branch has been published at **[https://marpit-api.marp.app/](https://marpit-api.marp.app/)**.
 
 Please run `yarn docs` if you want to build documentation at local. It would build docs in `jsdoc` directory.
 

--- a/api.md
+++ b/api.md
@@ -2,7 +2,7 @@
 
 The documentation of Marpit API on `master` branch has been published at **[https://marpit-api.marp.app/](https://marpit-api.marp.app/)**.
 
-Please run `yarn docs` if you want to build documentation at local. It would build docs in `jsdoc` directory.
+Please run `yarn jsdoc` if you want to build documentation at local. It would build docs in `jsdoc` directory.
 
 ## Classes
 

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "scripts": {
     "build": "yarn --mutex file run clean && babel src --out-dir lib",
     "clean": "rimraf lib",
-    "docs": "jsdoc src -c .jsdoc.json",
     "format": "prettier **/*.{json,md,ts,yaml,yml}",
     "format:check": "yarn --mutex file run format -l",
+    "jsdoc": "rimraf jsdoc && jsdoc src -c .jsdoc.json",
     "lint": "eslint",
     "lint:all": "eslint .",
     "prepack": "npm-run-all --npm-path yarn --parallel format:check lint:all test:coverage --sequential build",


### PR DESCRIPTION
From now on we use own domains https://marp.app/. This PR will update the hosted URL of Marpit API docs into https://marpit-api.marp.app/.

*NOTE: `marpit.marp.app` is reserved for docs about Marpit syntax.*