### PR TITLE
Use jsdelivr CDN on docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Support image resizing with `width` and `height` keyword ([#62](https://github.com/marp-team/marpit/pull/62))
-- Add document page on [https://marpit.marp.app/](https://marpit.marp.app/) ([#60](https://github.com/marp-team/marpit/pull/60), [#61](https://github.com/marp-team/marpit/pull/61))
+- Add document page on [https://marpit.marp.app/](https://marpit.marp.app/) ([#60](https://github.com/marp-team/marpit/pull/60), [#61](https://github.com/marp-team/marpit/pull/61), [#63](https://github.com/marp-team/marpit/pull/63))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://marpit.marp.app"><img src="./docs/marpit.png" alt="Marpit" width="500" /></a>
+    <a href="https://marpit.marp.app"><img src="https://github.com/marp-team/marpit/blob/master/docs/marpit.png?raw=true" alt="Marpit" width="500" /></a>
   </p>
   <p>
     <strong>Marpit</strong>: Markdown slide deck framework

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This framework is actually created for use as [a core][marp-core] of the next ve
 
 We have extended several features into [markdown-it](https://github.com/markdown-it/markdown-it) parser to support writing awesome slides, such as [Directives](#directives) and [Slide backgrounds](#slide-backgrounds). Additional syntaxes place importance on a compatibility with general Markdown documents.
 
-### [:art: **CSS theme by clear markup**](#theme-css)
+### [:art: **CSS theme by clean markup**](#theme-css)
 
 Marpit has the CSS theming system that can design slides everything. Unlike other slide frameworks, there are not any predefined classes and mixins. You have only to focus styling HTML elements by pure CSS. Marpit would take care of the selected theme's necessary conversion.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,8 +25,6 @@
       maxLevel: 4,
     }
   </script>
-  <script defer src="https://unpkg.com/docsify/lib/docsify.min.js"></script>
-  <script defer src="https://unpkg.com/docsify-copy-code"></script>
-  <script defer src="https://unpkg.com/docsify-themeable"></script>
+  <script defer src="https://cdn.jsdelivr.net/combine/npm/docsify@4/lib/docsify.min.js,npm/docsify-copy-code,npm/docsify-themeable@0.3"></script>
 </body>
 </html>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,17 +19,17 @@ This framework is actually created for use as [a core][marp-core] of the next ve
 
 ## Features
 
-- :pencil: **Marpit Markdown**
+### :pencil: Marpit Markdown {docsify-ignore}
 
-  - We have extended several features into [markdown-it](https://github.com/markdown-it/markdown-it) parser to support writing awesome slides, such as [_Directives_](https://github.com/marp-team/marpit#directives) and [_Slide backgrounds_](https://github.com/marp-team/marpit#slide-backgrounds). Additional syntaxes place importance on a compatibility with general Markdown documents.
+We have extended several features into [markdown-it](https://github.com/markdown-it/markdown-it) parser to support writing awesome slides, such as [_Directives_](https://github.com/marp-team/marpit#directives) and [_Slide backgrounds_](https://github.com/marp-team/marpit#slide-backgrounds). Additional syntaxes place importance on a compatibility with general Markdown documents.
 
-- :art: **CSS theme by clear markup**
+### :art: CSS theme by clear markup {docsify-ignore}
 
-  - Marpit has the CSS theming system that can design slides everything. Unlike other slide frameworks, there are not any predefined classes and mixins. You have only to focus styling HTML elements by pure CSS. Marpit would take care of the selected theme's necessary conversion.
+Marpit has the CSS theming system that can design slides everything. Unlike other slide frameworks, there are not any predefined classes and mixins. You have only to focus styling HTML elements by pure CSS. Marpit would take care of the selected theme's necessary conversion.
 
-- :triangular_ruler: **Inline SVG slide** <i>(Experimental)</i>
+### :triangular_ruler: Inline SVG slide <i>(Experimental)</i> {docsify-ignore}
 
-  - Optionally `<svg>` element can use as the container of each slide page. It can be realized the pixel-perfect scaling of the slide only by CSS, so handling slides in integrated apps become simplified. The isolated HTML space made by `<foreignObject>` can provide [_Advanced backgrounds_](https://github.com/marp-team/marpit#advanced-backgrounds-with-inline-svg-mode) for the slide with keeping the original Markdown DOM structure.
+Optionally `<svg>` element can use as the container of each slide page. It can be realized the pixel-perfect scaling of the slide only by CSS, so handling slides in integrated apps become simplified. The isolated HTML space made by `<foreignObject>` can provide [_Advanced backgrounds_](https://github.com/marp-team/marpit#advanced-backgrounds-with-inline-svg-mode) for the slide with keeping the original Markdown DOM structure.
 
 ?> We not provide any themes because Marpit is just a framework. You can use [@marp-team/marp-core][marp-core] if you want. It has the official themes, and practical features extended from Marpit.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -23,7 +23,7 @@ This framework is actually created for use as [a core][marp-core] of the next ve
 
 We have extended several features into [markdown-it](https://github.com/markdown-it/markdown-it) parser to support writing awesome slides, such as [_Directives_](https://github.com/marp-team/marpit#directives) and [_Slide backgrounds_](https://github.com/marp-team/marpit#slide-backgrounds). Additional syntaxes place importance on a compatibility with general Markdown documents.
 
-### :art: CSS theme by clear markup {docsify-ignore}
+### :art: CSS theme by clean markup {docsify-ignore}
 
 Marpit has the CSS theming system that can design slides everything. Unlike other slide frameworks, there are not any predefined classes and mixins. You have only to focus styling HTML elements by pure CSS. Marpit would take care of the selected theme's necessary conversion.
 


### PR DESCRIPTION
The unpkg CDN that is recommended by docsify seems not to be stable. We have to wait in blank screen sometimes.

This PR changes CDN provider from unpkg to jsdelivr. We have updated minor formatting on docs too.