### PR TITLE
Rename lazyYAML constructor option to looseYAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 
-- Renamed `lazyYAML` constructor option into `looseYAML`. ([#68](https://github.com/marp-team/marpit/pull/68))
+- Rename `lazyYAML` constructor option into `looseYAML` ([#68](https://github.com/marp-team/marpit/pull/68))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- Renamed `lazyYAML` constructor option into `looseYAML`. ([#68](https://github.com/marp-team/marpit/pull/68))
+
 ### Changed
 
 - Move documentation from README.md to [https://marpit.marp.app/](https://marpit.marp.app/) ([#67](https://github.com/marp-team/marpit/pull/67))

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -6,7 +6,7 @@ Marpit Markdown has extended syntax called **"Directives"** to support writing a
 
 The wrote directives would parse as [YAML](http://yaml.org/).
 
-When the value includes YAML special chars, you should wrap with quotes to be recognized correctly. You may enable a loose parsing by [`lazyYAML` Marpit constructor option](https://marpit-api.marp.app/marpit) if you want.
+When the value includes YAML special chars, you should wrap with quotes to be recognized correctly. You may enable a loose parsing by [`looseYAML` Marpit constructor option](https://marpit-api.marp.app/marpit) if you want.
 
 ### HTML comment
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module '@marp-team/marpit' {
     filters?: boolean
     headingDivider?: false | MarpitHeadingDivider | MarpitHeadingDivider[]
     inlineStyle?: boolean
-    lazyYAML?: boolean
+    looseYAML?: boolean
     markdown?: string | object | [string, object]
     printable?: boolean
     slideContainer?: false | Element | Element[]

--- a/src/markdown/comment.js
+++ b/src/markdown/comment.js
@@ -14,11 +14,11 @@ const commentMatcherClosing = /-->/
  * @alias module:markdown/comment
  * @param {MarkdownIt} md markdown-it instance.
  * @param {Object} [opts]
- * @param {boolean} [opts.lazyYAML=false] Allow lazy YAML for directives.
+ * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
  */
 function comment(md, opts = {}) {
   const parse = (token, content) => {
-    const parsed = yaml(content, !!opts.lazyYAML)
+    const parsed = yaml(content, !!opts.looseYAML)
 
     token.meta = {
       ...(token.meta || {}),

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -16,7 +16,7 @@ import { globals, locals } from './directives'
  * @param {boolean} [opts.frontMatter=true] Switch feature to support YAML
  *     front-matter. If true, you can use Jekyll style directive setting to the
  *     first page.
- * @param {boolean} [opts.lazyYAML=false] Allow lazy YAML for directives.
+ * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
  */
 function parse(md, marpit, opts = {}) {
   // Front-matter support
@@ -31,7 +31,7 @@ function parse(md, marpit, opts = {}) {
     md.use(MarkdownItFrontMatter, fm => {
       frontMatterObject.text = fm
 
-      const parsed = yaml(fm, !!opts.lazyYAML)
+      const parsed = yaml(fm, !!opts.looseYAML)
       if (parsed !== false) frontMatterObject.yaml = parsed
     })
   }

--- a/src/markdown/directives/yaml.js
+++ b/src/markdown/directives/yaml.js
@@ -7,13 +7,13 @@ import directives from './directives'
  *
  * @alias module:markdown/directives/yaml
  * @param {String} text Target text.
- * @param {boolean} allowLazy By `true`, it try to parse lazy YAML in defined
+ * @param {boolean} allowLoose By `true`, it try to parse loose YAML in defined
  *     directives.
  * @returns {Object|false} Return parse result, or `false` when failed to parse.
  */
 
 const keyPattern = `[_$]?(?:${directives.join('|')})`
-const lazyMatcher = new RegExp(`^(${keyPattern}\\s*:)(.+)$`)
+const looseMatcher = new RegExp(`^(${keyPattern}\\s*:)(.+)$`)
 const specialChars = `["'{|>~&*`
 
 function parse(text) {
@@ -27,12 +27,12 @@ function parse(text) {
   }
 }
 
-function convertLazy(text) {
+function convertLoose(text) {
   return text
     .split(/\r?\n/)
     .reduce(
       (ret, line) =>
-        `${ret}${line.replace(lazyMatcher, (original, prop, value) => {
+        `${ret}${line.replace(looseMatcher, (original, prop, value) => {
           const trimmed = value.trim()
 
           if (trimmed.length === 0 || specialChars.includes(trimmed[0]))
@@ -48,4 +48,5 @@ function convertLazy(text) {
     .trim()
 }
 
-export default (text, allowLazy) => parse(allowLazy ? convertLazy(text) : text)
+export default (text, allowLoose) =>
+  parse(allowLoose ? convertLoose(text) : text)

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -23,7 +23,7 @@ const defaultOptions = {
   filters: true,
   headingDivider: false,
   inlineStyle: true,
-  lazyYAML: false,
+  looseYAML: false,
   markdown: 'commonmark',
   printable: true,
   slideContainer: false,
@@ -54,7 +54,7 @@ class Marpit {
    * @param {boolean} [opts.inlineStyle=true] Recognize `<style>` elements to
    *     append additional styles to theme. When it is `true`, Marpit will parse
    *     style regardless markdown-it's `html` option.
-   * @param {boolean} [opts.lazyYAML=false] Allow lazy YAML for directives.
+   * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
    * @param {string|Object|Array} [opts.markdown='commonmark'] markdown-it
    *     initialize option(s).
    * @param {boolean} [opts.printable=true] Make style printable to PDF.
@@ -110,12 +110,12 @@ class Marpit {
 
   /** @private */
   applyMarkdownItPlugins(md = this.markdown) {
-    const { backgroundSyntax, filters, lazyYAML } = this.options
+    const { backgroundSyntax, filters, looseYAML } = this.options
 
-    md.use(marpitComment, { lazyYAML })
+    md.use(marpitComment, { looseYAML })
       .use(marpitStyleParse, this)
       .use(marpitSlide)
-      .use(marpitParseDirectives, this, { lazyYAML })
+      .use(marpitParseDirectives, this, { looseYAML })
       .use(marpitApplyDirectives)
       .use(marpitHeaderAndFooter)
       .use(marpitHeadingDivider, this)

--- a/test/markdown/directives/yaml.js
+++ b/test/markdown/directives/yaml.js
@@ -2,14 +2,14 @@ import dedent from 'dedent'
 import yaml from '../../../src/markdown/directives/yaml'
 
 describe('Marpit directives YAML parser', () => {
-  it("ignores directive's special char with false allowLazy option", () =>
+  it("ignores directive's special char with false allowLoose option", () =>
     expect(yaml('color: #f00', false).color).toBeNull())
 
-  context('with allowLazy option as true', () => {
+  context('with allowLoose option as true', () => {
     it("parses directive's special char as string", () =>
       expect(yaml('color: #f00', true).color).toBe('#f00'))
 
-    it('disallows lazy parsing in not defined directives', () => {
+    it('disallows loose parsing in not defined directives', () => {
       const body = dedent`
         backgroundColor: #f00
         header: _"HELLO!"_

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -185,8 +185,8 @@ describe('Marpit', () => {
       })
     })
 
-    context('with lazyYAML option', () => {
-      const instance = lazyYAML => new Marpit({ lazyYAML })
+    context('with looseYAML option', () => {
+      const instance = looseYAML => new Marpit({ looseYAML })
       const markdown = dedent`
         ---
         backgroundImage:  url('/image.jpg')
@@ -196,7 +196,7 @@ describe('Marpit', () => {
         ---
       `
 
-      it('allows lazy YAML parsing when lazyYaml is true', () => {
+      it('allows loose YAML parsing when looseYAML is true', () => {
         const rendered = instance(true).render(markdown)
         const $ = cheerio.load(rendered.html)
         const firstStyle = $('section:nth-of-type(1)').attr('style')
@@ -208,7 +208,7 @@ describe('Marpit', () => {
         expect(secondStyle).not.toContain('color:')
       })
 
-      it('disallows lazy YAML parsing when lazyYaml is false', () => {
+      it('disallows loose YAML parsing when looseYAML is false', () => {
         const rendered = instance(false).render(markdown)
         const $ = cheerio.load(rendered.html)
         const style = $('section:nth-of-type(1)').attr('style')


### PR DESCRIPTION
This PR will rename Marpit's `lazyYAML` constructor option into `looseYAML`.

The word of "lazy" conjures images of delay processing. The word of "loose" suggesting to be allowed special chars in YAML value is better than "lazy".

Next release will become the first minor release. (`0.1.0`) Thus, this timing is the best for including a breaking change.