### PR TITLE
Roll up at-rules before parsing import rules for theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix that `before` option of `ThemeSet.pack` breaks importing another theme ([#71](https://github.com/marp-team/marpit/pull/71), [#72](https://github.com/marp-team/marpit/pull/72))
+
 ## v0.1.0 - 2018-09-14
 
 ### Breaking

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -201,6 +201,7 @@ class ThemeSet {
       [
         before && (css => css.first.before(before)),
         after && (css => css.last.after(after)),
+        postcssImportRollup,
         postcssImportReplace(this),
         opts.printable &&
           postcssPrintable({

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -252,4 +252,19 @@ describe('ThemeSet', () => {
       expect([...themes].map(t => t.name)).toStrictEqual(['test1', 'test2'])
     })
   })
+
+  describe('#pack', () => {
+    context('with before option', () => {
+      const before = 'b { font-weight: bold; }'
+
+      it('rolls-up @import rule to top for importing another theme', () => {
+        instance.add('/* @theme test1 */ strong { font-weight: bold; }')
+        instance.add('/* @theme test2 */ @import "test1";')
+
+        const css = instance.pack('test2', { before })
+        expect(css).toContain('b { font-weight: bold; }')
+        expect(css).toContain('strong { font-weight: bold; }')
+      })
+    })
+  })
 })

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -255,15 +255,26 @@ describe('ThemeSet', () => {
 
   describe('#pack', () => {
     context('with before option', () => {
-      const before = 'b { font-weight: bold; }'
-
       it('rolls-up @import rule to top for importing another theme', () => {
         instance.add('/* @theme test1 */ strong { font-weight: bold; }')
         instance.add('/* @theme test2 */ @import "test1";')
 
-        const css = instance.pack('test2', { before })
+        const css = instance.pack('test2', {
+          before: 'b { font-weight: bold; }',
+        })
+
         expect(css).toContain('b { font-weight: bold; }')
         expect(css).toContain('strong { font-weight: bold; }')
+      })
+
+      it('ignores when passed invalid CSS', () => {
+        let css
+
+        expect(() => {
+          css = instance.pack(undefined, { before: 'INVALID */' })
+        }).not.toThrowError()
+
+        expect(css).not.toContain('INVALID')
       })
     })
   })


### PR DESCRIPTION
This PR will roll-up CSS at-rules before parsing import rules for theme.

We are already using [PostCSS import rollup plugin](https://marpit-api.marp.app/module-postcss_import_rollup.html) for finalize. It also can apply as a pre-process before parsing import rules.

Fix #71.

***BONUS:*** The test of `before` option is the only lacked test. We have filled it and marked 100% line coverage.