### PR TITLE
Fix to parse metadata of theme within important comments

### DIFF
--- a/src/postcss/meta.js
+++ b/src/postcss/meta.js
@@ -15,7 +15,7 @@ const plugin = postcss.plugin('marpit-postcss-meta', () => (css, ret) => {
     comment.text
       .slice(0)
       .replace(
-        /^[*\s]*@([a-z][a-z0-9]*)\s+(.+)$/gim,
+        /^[*!\s]*@([a-z][a-z0-9]*)\s+(.+)$/gim,
         (matched, metaName, value) => {
           ret.marpitMeta[metaName] = value
         }

--- a/test/postcss/meta.js
+++ b/test/postcss/meta.js
@@ -16,6 +16,16 @@ describe('Marpit PostCSS meta plugin', () => {
       expect(result.marpitMeta.meta).toBe('value')
     ))
 
+  it('parses meta comment with starting by double star', () =>
+    run('/** @meta double-star */').then(result =>
+      expect(result.marpitMeta.meta).toBe('double-star')
+    ))
+
+  it('parses meta comment with important comment', () =>
+    run('/*! @meta important-comment */').then(result =>
+      expect(result.marpitMeta.meta).toBe('important-comment')
+    ))
+
   context('with multiline metas', () => {
     const css = `
       /**


### PR DESCRIPTION
`/*! @theme foobar */` will become to work. Fix #74.