### PR TITLE
Update documentation of customized theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix to parse metadata of theme within important comments ([#74](https://github.com/marp-team/marpit/pull/74), [#76](https://github.com/marp-team/marpit/pull/76))
+- Update [documentation of customized theme](https://marpit.marp.app/theme-css?id=customized-theme) to apply changed behavior on v0.1.1 ([#75](https://github.com/marp-team/marpit/pull/75), [#77](https://github.com/marp-team/marpit/pull/77))
 
 ## v0.1.1 - 2018-09-18
 

--- a/docs/theme-css.md
+++ b/docs/theme-css.md
@@ -142,9 +142,7 @@ section {
 }
 ```
 
-`@import` must precede all other statements excepted `@charset`. It follows [the original specification][@import].
-
-In addition, an importing theme must add to theme set by using [`Marpit.themeSet.add(css)`](/usage#add-to-theme-set) in advance.
+An importing theme must add to theme set by using [`Marpit.themeSet.add(css)`](/usage#add-to-theme-set) in advance.
 
 ### `@import-theme` rule
 
@@ -164,7 +162,7 @@ section {
 }
 ```
 
-Unlike `@import`, `@import-theme` can place on anywhere of the root of CSS. The imported contents is inserted to the beginning of CSS in order.
+`@import` for theme and `@import-theme` can place on anywhere of the root of CSS. The imported contents is inserted to the beginning of CSS in order per rules. (`@import` is processed before `@import-theme`)
 
 ## Tweak style through Markdown
 


### PR DESCRIPTION
Fix #75. Since v0.1.1, `@import` rule could work correctly in anywhere of the CSS root.