### PR TITLE
Update license author to marp-team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update license author to marp-team ([#81](https://github.com/marp-team/marpit/pull/81))
+
 ## v0.1.3 - 2018-10-05
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Yuki Hattori (yukihattori1116@gmail.com)
+Copyright (c) 2018 Marp team (marp-team@marp.app)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We have prepared a mail address of marp-team. It's good to use team address instead of maintainer's personal address to show LICENSE.