### PR TITLE
Collect HTML comment per pages to be usable as presenter note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Collect HTML comments per page to be usable as presenter note ([#82](https://github.com/marp-team/marpit/issues/82), [#83](https://github.com/marp-team/marpit/pull/83))
+
 ### Changed
 
 - Update license author to marp-team ([#81](https://github.com/marp-team/marpit/pull/81))

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -17,6 +17,8 @@ paginate: true
 -->
 ```
 
+?> The HTML comment is also used for [presenter notes](http://localhost:3000/usage?id=presenter-notes). When it is parsed as a directive, it would not be collected in the `comments` result of `Marpit.render()`.
+
 ### Front-matter
 
 Marpit also supports [YAML front-matter](https://jekyllrb.com/docs/frontmatter/), that is a syntax often used for keeping metadata of Markdown. It must be the first thing of Markdown, and between the dash rulers.

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -17,7 +17,7 @@ paginate: true
 -->
 ```
 
-?> The HTML comment is also used for [presenter notes](http://localhost:3000/usage?id=presenter-notes). When it is parsed as a directive, it would not be collected in the `comments` result of `Marpit.render()`.
+?> The HTML comment is also used for [presenter notes](/usage?id=presenter-notes). When it is parsed as a directive, it would not be collected in the `comments` result of `Marpit.render()`.
 
 ### Front-matter
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,8 +82,8 @@ const marpit = new Marpit({
 Now, let's render Markdown. Just only pass a string of Markdown to [**`marpit.render(markdown)`**](https://marpit-api.marp.app/marpit#render).
 
 ```javascript
-// Output rendered HTML and CSS
-const { html, css } = marpit.render('# Hello, Marpit!')
+// Output rendered HTML, CSS, and collected HTML comments (See "Advanced")
+const { html, css, comments } = marpit.render('# Hello, Marpit!')
 ```
 
 The HTML output is like this. (Formatted)
@@ -138,6 +138,48 @@ marpit.themeSet.default = marpit.themeSet.add('...')
 ```
 
 [The applied example is here.](/assets/hello-marpit-theme.pdf ':ignore')
+
+## Advanced
+
+### Presenter notes
+
+Marpit can collect HTML comments written in Markdown while rendering, except [directives](/directives). The collected `comments` are returned in the result of [`marpit.render()`](https://marpit-api.marp.app/marpit#render).
+
+You may use it as the presenter notes in Marpit integrated apps.
+
+```javascript
+const { comments } = marpit.render(`
+<!-- theme: default -->
+
+# First page
+
+<!-- HTML comment recognizes as a presenter note per pages. -->
+<!-- You may place multiple comments in a single page. -->
+
+---
+
+## Second page
+
+<!--
+Also supports multiline.
+We bet these comments would help your presentation...
+-->
+`)
+```
+
+The returned value is a two-dimensional array composed by comments per slide pages.
+
+```json
+[
+  [
+    "HTML comment recognizes as a presenter note per pages.",
+    "You may place multiple comments in a single page."
+  ],
+  [
+    "Also supports multiline.\nWe bet these comments would help your presentation..."
+  ]
+]
+```
 
 ## Full API documentation
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare module '@marp-team/marpit' {
   type MarpitRenderResult = {
     html: string
     css: string
+    comments: string[][]
   }
 
   type ThemeSetPackOptions = {
@@ -36,7 +37,7 @@ declare module '@marp-team/marpit' {
     readonly options: MarpitOptions
     readonly markdownItPlugins: (md: any) => void
 
-    protected lastComments?: string[][]
+    protected lastComments?: MarpitRenderResult['comments']
     protected lastGlobalDirectives?: { [directive: string]: any }
     protected lastStyles?: string[]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,7 @@ declare module '@marp-team/marpit' {
     readonly options: MarpitOptions
     readonly markdownItPlugins: (md: any) => void
 
+    protected lastComments?: string[][]
     protected lastGlobalDirectives?: { [directive: string]: any }
     protected lastStyles?: string[]
 

--- a/src/markdown/collect_comment.js
+++ b/src/markdown/collect_comment.js
@@ -1,0 +1,52 @@
+/** @module */
+
+/**
+ * Marpit collect comment plugin.
+ *
+ * Collect parsed comments except marked as used for internally, and store to
+ * lastComments member of Marpit instance. It would use in the returned object
+ * from {@link Marpit#render}.
+ *
+ * @alias module:markdown/collect_comment
+ * @param {MarkdownIt} md markdown-it instance.
+ * @param {Marpit} marpit Marpit instance.
+ */
+function collectComment(md, marpit) {
+  md.core.ruler.push('marpit_collect_comment', state => {
+    if (state.inlineMode) return
+
+    marpit.lastComments = []
+
+    let currentPage
+
+    const collect = token => {
+      if (
+        currentPage >= 0 &&
+        !(token.meta && token.meta.marpitCommentParsed !== undefined)
+      )
+        marpit.lastComments[currentPage].push(token.content)
+    }
+
+    for (const token of state.tokens) {
+      if (
+        token.type === 'marpit_slide_open' &&
+        token.meta &&
+        token.meta.marpitSlide !== undefined
+      ) {
+        currentPage = token.meta.marpitSlide
+
+        if (currentPage >= 0 && marpit.lastComments[currentPage] === undefined)
+          marpit.lastComments[currentPage] = []
+      } else if (token.type === 'marpit_slide_close') {
+        currentPage = undefined
+      } else if (token.type === 'marpit_comment') {
+        collect(token)
+      } else if (token.type === 'inline') {
+        for (const t of token.children)
+          if (t.type === 'marpit_comment') collect(t)
+      }
+    }
+  })
+}
+
+export default collectComment

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -135,6 +135,8 @@ class Marpit {
    * @typedef {Object} Marpit~RenderResult
    * @property {string} html Rendered HTML.
    * @property {string} css Rendered CSS.
+   * @property {string[][]} comments Parsed HTML comments per slide pages,
+   *     excepted YAML for directives. It would be useful for presenter notes.
    */
 
   /**

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -4,6 +4,7 @@ import ThemeSet from './theme_set'
 import { marpitContainer } from './element'
 import marpitApplyDirectives from './markdown/directives/apply'
 import marpitBackgroundImage from './markdown/background_image'
+import marpitCollectComment from './markdown/collect_comment'
 import marpitComment from './markdown/comment'
 import marpitContainerPlugin from './markdown/container'
 import marpitHeaderAndFooter from './markdown/header_and_footer'
@@ -125,6 +126,7 @@ class Marpit {
       .use(marpitSweep)
       .use(marpitInlineSVG, this)
       .use(marpitStyleAssign, this)
+      .use(marpitCollectComment, this)
 
     if (backgroundSyntax) md.use(marpitBackgroundImage)
   }
@@ -145,6 +147,7 @@ class Marpit {
     return {
       html: this.renderMarkdown(markdown),
       css: this.renderStyle(this.lastGlobalDirectives.theme),
+      comments: this.lastComments,
     }
   }
 

--- a/test/markdown/collect_comment.js
+++ b/test/markdown/collect_comment.js
@@ -60,6 +60,13 @@ describe('Marpit collect comment plugin', () => {
     # Fourth <!-- inline comment --> page
   `
 
+  it('ignores in #renderInline', () => {
+    const marpit = marpitStub()
+    md(marpit).renderInline(text)
+
+    expect(marpit.lastComments).toBeUndefined()
+  })
+
   it("collects comments and store to Marpit's lastComments member", () => {
     const marpit = marpitStub()
     md(marpit).render(text)

--- a/test/markdown/collect_comment.js
+++ b/test/markdown/collect_comment.js
@@ -1,0 +1,123 @@
+import dedent from 'dedent'
+import MarkdownIt from 'markdown-it'
+import applyDirectives from '../../src/markdown/directives/apply'
+import collectComment from '../../src/markdown/collect_comment'
+import comment from '../../src/markdown/comment'
+import parseDirectives from '../../src/markdown/directives/parse'
+import slide from '../../src/markdown/slide'
+
+describe('Marpit collect comment plugin', () => {
+  const themeSet = new Map()
+  themeSet.set('default', true)
+
+  const marpitStub = () => ({
+    themeSet,
+    lastGlobalDirectives: {},
+  })
+
+  const md = marpitInstance =>
+    new MarkdownIt('commonmark')
+      .use(comment)
+      .use(slide)
+      .use(parseDirectives, { themeSet: marpitInstance.themeSet })
+      .use(applyDirectives)
+      .use(collectComment, marpitInstance)
+
+  const text = dedent`
+    ---
+    frontMatter: would not correct
+    ---
+
+    # First page
+
+    <!-- This is comment -->
+    <!--
+    multiline
+    comment
+    -->
+
+    ---
+
+    # Second page
+
+    <!-- theme: default -->
+    <!--
+    color: white
+    note: Comment would not collect if yaml has included correct directive.
+    -->
+    <!--
+    note: "Comment would collect if yaml has only invalid directive."
+    -->
+
+    ---
+
+    # Third page
+
+    <!-- theme: is-invalid-theme-but-not-collect-because-theme-iss-correct-directive -->
+
+    ---
+
+    # Fourth <!-- inline comment --> page
+  `
+
+  it("collects comments and store to Marpit's lastComments member", () => {
+    const marpit = marpitStub()
+    md(marpit).render(text)
+
+    const { lastComments } = marpit
+
+    expect(lastComments).toHaveLength(4)
+    expect(lastComments[0]).toStrictEqual([
+      'This is comment',
+      'multiline\ncomment',
+    ])
+    expect(lastComments[1]).toStrictEqual([
+      expect.stringContaining(
+        'Comment would collect if yaml has only invalid directive'
+      ),
+    ])
+    expect(lastComments[2]).toHaveLength(0)
+    expect(lastComments[3]).toStrictEqual(['inline comment'])
+  })
+
+  context(
+    'when comment token is marked marpitCommentParsed meta in other plugin',
+    () => {
+      it('ignores collecting comment', () => {
+        const marpit = marpitStub()
+
+        md(marpit)
+          .use(mdIt => {
+            mdIt.core.ruler.before(
+              'marpit_slide',
+              'marpit_test_inject',
+              state => {
+                const markParsed = token => {
+                  token.meta = {
+                    ...(token.meta || {}),
+                    marpitCommentParsed: 'test',
+                  }
+                }
+
+                for (const token of state.tokens) {
+                  if (token.content === 'This is comment') {
+                    markParsed(token)
+                  } else if (token.type === 'inline') {
+                    for (const t of token.children)
+                      if (t.content === 'inline comment') markParsed(t)
+                  }
+                }
+              }
+            )
+          })
+          .render(text)
+
+        const { lastComments } = marpit
+
+        expect(lastComments[0]).toHaveLength(1)
+        expect(lastComments[0]).not.toContain('This is comment')
+        expect(lastComments[3]).toHaveLength(0)
+      })
+    }
+  )
+})

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -82,6 +82,19 @@ describe('Marpit directives parse plugin', () => {
         md().parse('<!-- $theme: test_theme -->')
         expect(marpitStub.lastGlobalDirectives).toStrictEqual(expected)
       })
+
+      it('marks directive comments as parsed', () => {
+        const findToken = tk => tk.find(t => t.type === 'marpit_comment')
+
+        const regularTheme = findToken(md().parse('<!-- theme: test_theme -->'))
+        expect(regularTheme.meta.marpitCommentParsed).toBe('directive')
+
+        const invalidTheme = findToken(md().parse('<!-- theme: test -->'))
+        expect(invalidTheme.meta.marpitCommentParsed).toBe('directive')
+
+        const regularComment = findToken(md().parse('<!-- regular comment -->'))
+        expect(regularComment.meta.marpitCommentParsed).toBeUndefined()
+      })
     })
   })
 
@@ -89,7 +102,7 @@ describe('Marpit directives parse plugin', () => {
     it('applies meta to the defined slide and followed slides', () => {
       const text = dedent`
         ***
-        <!-- class: test -->
+        Inline<!-- class: test -->comment
         ***
         <!-- notDefined: directive -->
         <!-- @invalid_yaml@ -->

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -54,13 +54,14 @@ describe('Marpit', () => {
   })
 
   describe('#render', () => {
-    it('returns the object contains html and css member', () => {
+    it('returns the object contains html, css, and comments', () => {
       const markdown = '# Hello'
       const instance = new Marpit()
 
       instance.renderMarkdown = md => {
         expect(md).toBe(markdown)
         instance.lastGlobalDirectives = { theme: 'dummy-theme' }
+        instance.lastComments = [['A', 'B', 'C']]
         return 'HTML'
       }
 
@@ -74,8 +75,11 @@ describe('Marpit', () => {
         return 'CSS'
       }
 
-      const ret = instance.render(markdown)
-      expect(ret).toStrictEqual({ html: 'HTML', css: 'CSS' })
+      expect(instance.render(markdown)).toStrictEqual({
+        html: 'HTML',
+        css: 'CSS',
+        comments: [['A', 'B', 'C']],
+      })
     })
 
     context('with inlineSVG option', () => {


### PR DESCRIPTION
This PR will collect HTML comment per pages (except YAML for directives) and return to `comments` member in `Marpit#render` after rendered. It will expect to be used as *presenter notes* in integrated apps.

By this change, `comments` member is added to the result of `Marpit.render()`. It's a double-dimensional string array.

```javascript
const md = `
<!-- theme: default -->

# Hello, world!

<!-- Comments (for presenter note) -->
<!--
To keep a compatibillity with general markdown document, we're using HTML
comments to be realize the presenter note of slide deck.
-->

---
<!-- backgroundColor: black -->

## Marpit framework

<!-- It would collect HTML comments except YAML for directives. -->
`
const marpit = new Marpit()
const { comments } = marpit.render(md)
console.log(comments)
```

```javascript
[ [ 'Comments (for presenter note)',
    'To keep a compatibillity with general markdown document, we\'re using HTML\ncomments to be realize the presenter note of slide deck.' ],
  [ 'It would collect HTML comments except YAML for directives.' ] ]
```

Currently Marpit won't handle the parsed comments and treat as plain text(s). The integrated app can use comments as presenter note, and you can be post-processing by another markdown parser if you want any styling.

Closes #82.

### ToDo

- [x] Update TypeScript definition
- [x] Update JSDoc
- [x] Update docs
- [x] Update CHANGELOG.md