### PR TITLE
Remove defer attribute from inline script tag on docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div id="app"></div>
-  <script defer>
+  <script>
     window.$docsify = {
       name: 'Marpit',
       repo: 'https://github.com/marp-team/marpit',


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer), `defer` attribute of inline `<script>` element would have no effect.

Marpit has defined `defer` attr to inline script on docs. So we can remove this attribute safely.