### PR TITLE
Update docsify scripts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,6 @@
       maxLevel: 4,
     }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/combine/npm/docsify@4/lib/docsify.min.js,npm/docsify-copy-code,npm/docsify-themeable@0.3,npm/prismjs@1.15/components/prism-bash.min.js,npm/prismjs@1.15/components/prism-markdown.min.js,npm/prismjs@1.15/components/prism-scss.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/combine/npm/docsify@4.7/lib/docsify.min.js,npm/docsify-copy-code,npm/docsify-themeable@0.5,npm/prismjs@1.15/components/prism-bash.min.js,npm/prismjs@1.15/components/prism-markdown.min.js,npm/prismjs@1.15/components/prism-scss.min.js,npm/prismjs@1.15/components/prism-json.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR will update the bundled docsify scripts in docs.

- Downgrade docisfy to 4.7 by strange renderings about header and emoji. The latest version of docsify has breakings about image syntax `![]()` and emoji `:shorthand:`. (https://github.com/docsifyjs/docsify/issues/681)

|[4.7.x](#)|[Latest (4.8.x)](https://5bdf3ef6b13fb14e603f9669--marpit.netlify.com/)|
|:---:|:---:|
|![screenshot_2018-11-05 introduction - marpit the skinny framework for creating slide deck from markdown 1](https://user-images.githubusercontent.com/3993388/47968645-3867e900-e0b0-11e8-8adb-c541bfb3e871.png)|![screenshot_2018-11-05 introduction - marpit the skinny framework for creating slide deck from markdown](https://user-images.githubusercontent.com/3993388/47968606-f5a61100-e0af-11e8-88e8-c1e6cef1fe2e.png)|

- Upgrade docsify-themeable to 0.5. It might have to give a feedback into [marp-team/marp](https://github.com/marp-team/marp).
- Add a lacked JSON PrismJS style. It is used in the result example of presenter note.