### PR TITLE
Disable CSS scoping into declarations within keyframes at-rule

### DIFF
--- a/src/postcss/pseudo_selector/prepend.js
+++ b/src/postcss/pseudo_selector/prepend.js
@@ -13,6 +13,9 @@ const plugin = postcss.plugin(
   'marpit-postcss-pseudo-selector-prepend',
   () => css =>
     css.walkRules(rule => {
+      const { type, name } = rule.parent || {}
+      if (type === 'atrule' && name === 'keyframes') return
+
       rule.selectors = rule.selectors.map(selector => {
         if (/^section(?![\w-])/.test(selector))
           return `:marpit-container > :marpit-slide${selector.slice(7)}`

--- a/test/postcss/pseudo_selector/prepend.js
+++ b/test/postcss/pseudo_selector/prepend.js
@@ -51,14 +51,32 @@ describe('Marpit PostCSS pseudo selector prepending plugin', () => {
       :marpit-container > div { background: #fff; }
     `
 
-    return run(css).then(result => {
-      result.root.walkRules(rule => {
-        rule.selectors.forEach(selector => {
-          expect(selector.startsWith(':marpit-container > :marpit-slide')).toBe(
-            false
-          )
-        })
-      })
+    return run(css).then(({ root }) => {
+      const collected = []
+      root.walkRules(({ selectors }) => collected.push(...selectors))
+
+      expect(collected).toStrictEqual([
+        'html',
+        'body',
+        ':marpit-container > div',
+      ])
+    })
+  })
+
+  it('does not prepend pseudo selectors within @keyframes', () => {
+    const css = dedent`
+      @keyframes spin {
+        from { transform: rotate(0deg); }
+        80% { transform: rotate(390deg); }
+        to { transform: rotate(360deg); }
+      }
+    `
+
+    return run(css).then(({ root }) => {
+      const collected = []
+      root.walkRules(({ selector }) => collected.push(selector))
+
+      expect(collected).toStrictEqual(['from', '80%', 'to'])
     })
   })
 })


### PR DESCRIPTION
This PR will check the parent at-rule when prepending internal pseudo-selector for scoping. If there is a declaration within `@keyframes`, Marpit will not prepend `:marpit-container` and `:marpit-slide`.

Fix #97.