### PR TITLE
Remove the exception of CSS scoping for html and body tag

### DIFF
--- a/src/postcss/pseudo_selector/prepend.js
+++ b/src/postcss/pseudo_selector/prepend.js
@@ -20,8 +20,7 @@ const plugin = postcss.plugin(
         if (/^section(?![\w-])/.test(selector))
           return `:marpit-container > :marpit-slide${selector.slice(7)}`
 
-        if (/^(:marpit-container|html|body)(?![\w-])/.test(selector))
-          return selector
+        if (selector.startsWith(':marpit-container')) return selector
 
         return `:marpit-container > :marpit-slide ${selector}`
       })

--- a/test/postcss/pseudo_selector/prepend.js
+++ b/test/postcss/pseudo_selector/prepend.js
@@ -5,78 +5,61 @@ import prepend from '../../../src/postcss/pseudo_selector/prepend'
 describe('Marpit PostCSS pseudo selector prepending plugin', () => {
   const run = input => postcss([prepend()]).process(input, { from: undefined })
 
-  it('prepends Marpit pseudo selectors to each rule', () => {
-    const css = dedent`
+  it('prepends Marpit pseudo selectors to each rule', () =>
+    run(dedent`
       h1 { font-size: 40px; }
       h2, h3 { font-size: 30px; }
-    `
-
-    return run(css).then(result => {
-      result.root.walkRules(rule => {
-        rule.selectors.forEach(selector => {
-          expect(
-            selector.startsWith(':marpit-container > :marpit-slide h')
-          ).toBe(true)
-        })
-      })
-    })
-  })
-
-  it('replaces section selector into :marpit-slide pseudo element', () => {
-    const css = dedent`
-      section { background: #fff; }
-      section::after { color: #666; }
-      section.invert { background: #000; }
-      section-like-element { color: red; }
-    `
-
-    return run(css).then(result => {
-      const rules = []
-      result.root.walkRules(rule => rules.push(...rule.selectors))
-
-      expect(rules).toContain(':marpit-container > :marpit-slide')
-      expect(rules).toContain(':marpit-container > :marpit-slide::after')
-      expect(rules).toContain(':marpit-container > :marpit-slide.invert')
-
-      // Custom Elements
-      expect(rules).toContain(
-        ':marpit-container > :marpit-slide section-like-element'
-      )
-    })
-  })
-
-  it('ignores root html, body and :marpit-container pseudo element', () => {
-    const css = dedent`
       html, body { margin: 0; }
-      :marpit-container > div { background: #fff; }
-    `
-
-    return run(css).then(({ root }) => {
+    `).then(({ root }) => {
       const collected = []
       root.walkRules(({ selectors }) => collected.push(...selectors))
 
       expect(collected).toStrictEqual([
-        'html',
-        'body',
-        ':marpit-container > div',
+        ':marpit-container > :marpit-slide h1',
+        ':marpit-container > :marpit-slide h2',
+        ':marpit-container > :marpit-slide h3',
+        ':marpit-container > :marpit-slide html',
+        ':marpit-container > :marpit-slide body',
       ])
-    })
-  })
+    }))
 
-  it('does not prepend pseudo selectors within @keyframes', () => {
-    const css = dedent`
+  it('replaces section selector into :marpit-slide pseudo element', () =>
+    run(dedent`
+      section { background: #fff; }
+      section::after { color: #666; }
+      section.invert { background: #000; }
+      section-like-element { color: red; }
+    `).then(({ root }) => {
+      const collected = []
+      root.walkRules(({ selectors }) => collected.push(...selectors))
+
+      expect(collected).toStrictEqual([
+        ':marpit-container > :marpit-slide',
+        ':marpit-container > :marpit-slide::after',
+        ':marpit-container > :marpit-slide.invert',
+        ':marpit-container > :marpit-slide section-like-element', // Custom Elements
+      ])
+    }))
+
+  it('does not prepend selectors to :marpit-container pseudo element', () =>
+    run(':marpit-container > div { background: #fff; }').then(({ root }) => {
+      const collected = []
+      root.walkRules(({ selectors }) => collected.push(...selectors))
+
+      expect(collected).toStrictEqual([':marpit-container > div'])
+    }))
+
+  it('does not prepend selectors within @keyframes', () =>
+    run(dedent`
       @keyframes spin {
         from { transform: rotate(0deg); }
         80% { transform: rotate(390deg); }
         to { transform: rotate(360deg); }
       }
-    `
-
-    return run(css).then(({ root }) => {
+    `).then(({ root }) => {
       const collected = []
       root.walkRules(({ selector }) => collected.push(selector))
 
       expect(collected).toStrictEqual(['from', '80%', 'to'])
-    })
-  })
+    }))
 })


### PR DESCRIPTION
This PR will remove the exception of CSS scoping for `html` and `body` tag. It means that `html` and `body` can no longer be styling through Marpit theme CSS.

Resolve #98.