### PR TITLE
Add use method to extend markdown-it parser by plugin

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,14 @@ declare module '@marp-team/marpit' {
     protected lastStyles?: string[]
 
     render(markdown: string): MarpitRenderResult
+    use<P extends any[]>(
+      plugin: (
+        this: Marpit['markdown'],
+        md: Marpit['markdown'],
+        ...params: P
+      ) => void,
+      ...params: P
+    ): this
 
     protected applyMarkdownItPlugins(md: any): void
     protected renderMarkdown(markdown: string): string

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -193,6 +193,18 @@ class Marpit {
       printable: this.options.printable,
     }
   }
+
+  /**
+   * Load the specified markdown-it plugin with given parameters.
+   *
+   * @param {Function} plugin markdown-it plugin.
+   * @param {...*} params Params to pass into plugin.
+   * @returns {Marpit} The called {@link Marpit} instance for chainable.
+   */
+  use(plugin, ...params) {
+    plugin.call(this.markdown, this.markdown, ...params)
+    return this
+  }
 }
 
 export default Marpit

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -272,4 +272,18 @@ describe('Marpit', () => {
       expect(instance.renderStyle('test-theme')).toBe('style of test-theme')
     })
   })
+
+  describe('#use', () => {
+    it('extends markdown-it parser by passed plugin', () => {
+      const instance = new Marpit()
+      const plugin = jest.fn((md, param) => {
+        md.extended = param
+      })
+
+      expect(instance.use(plugin, 'parameter')).toBe(instance)
+      expect(plugin).toBeCalledTimes(1)
+      expect(plugin).toBeCalledWith(instance.markdown, 'parameter')
+      expect(instance.markdown.extended).toBe('parameter')
+    })
+  })
 })


### PR DESCRIPTION
Added `Marpit.use()` instance method to extend markdown-it parser by plugin.

*It is exactly same meaning as `Marpit.markdown.use()`*, but it returns `Marpit` instance as chainable. It becomes easy to customize Marpit (Marp Core) especially in a functional engine implemented in Marp CLI (marp-team/marp-cli#42).

## Usage in [Marp Core](https://github.com/marp-team/marp-core) / [Marp CLI](https://github.com/marp-team/marp-cli)

```javascript
// marp.config.js
const { Marp } = require('@marp-team/marp-core')
const container = require('markdown-it-container')
const mark = require('markdown-it-mark')

module.exports = {
  engine: opts => new Marp(opts).use(container, 'columns').use(mark),
}
```

```markdown
<style>.columns { column-count: 2; }</style>

# Extend parser by ==markdown-it plugin==

::: columns
Lorem ipsum dolor sit amet, nec ex illud viderer vivendo, mea semper deleniti cu. His in brute justo. Vim facilisis dissentiet ei. Per cu efficiendi theophrastus, te pro dicta mucius, ut sed adhuc ponderum. No iriure convenire pri, ius at possit appareat disputando, mei ei libris oportere.
:::
```

![deck](https://user-images.githubusercontent.com/3993388/49327156-d613e280-f5a0-11e8-9e36-1f830d7b250c.png)

> [`markdown-it-mark`](https://github.com/markdown-it/markdown-it-mark) is using in [the pre-released Marp](https://github.com/yhatt/marp) but we are not planned to adopt in Marpit and Marp Core by not-standard syntax. [`markdown-it-container`](https://github.com/markdown-it/markdown-it-container) is also not adopted by the same reason.
>
> However, this customization will help needed user. The example of multi column is one of the alternative way to r​esolve yhatt/marp#82.
### ToDo

- [x] Add test