### PR TITLE
Add normalization of HTML background in printable style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent leaking header and footer when printing by added normalization of HTML background ([#108](https://github.com/marp-team/marpit/pull/108), [#109](https://github.com/marp-team/marpit/pull/109))
+
 ## v0.4.0 - 2018-12-02
 
 ### Added

--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -1,6 +1,14 @@
 /** @module */
 import postcss from 'postcss'
 
+const marpitPrintContainerStyle = `
+html, body {
+  background-color: #fff;
+  margin: 0;
+  page-break-inside: avoid;
+}
+`.trim()
+
 /**
  * Marpit PostCSS printable plugin.
  *
@@ -55,7 +63,7 @@ export const postprocess = postcss.plugin(
       if (rule.params !== 'marpit-print') return
 
       rule.params = 'print'
-      rule.first.before('html, body { margin: 0; page-break-inside: avoid; }')
+      rule.first.before(marpitPrintContainerStyle)
     })
 )
 


### PR DESCRIPTION
I added the normalization of HTML background in printable style.

Sometimes Chrome 71 leaks printing header and footer unfortunately. Added normalization of background color in printing can prevent it.

The fixed PDF is [here](https://github.com/marp-team/marpit/files/2689143/normalized.pdf). It resolves #108.