### PR TITLE
Fix the version badge in docs sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Prevent leaking header and footer when printing by added normalization of HTML background ([#108](https://github.com/marp-team/marpit/pull/108), [#109](https://github.com/marp-team/marpit/pull/109))
+- Fix the version badge in docs sidebar ([#110](https://github.com/marp-team/marpit/pull/108))
 
 ## v0.4.0 - 2018-12-02
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -10,4 +10,4 @@
 
 - [![Marpit API](https://icongr.am/material/open-in-new.svg?size=24&color=808080)Marpit API (JSDoc)](https://marpit-api.marp.app/)
 - [![GitHub](https://icongr.am/material/github-circle.svg?size=24&color=808080)GitHub](https://github.com/marp-team/marpit)
-- [![npm](https://icongr.am/material/npm.svg?size=24&color=808080)npm![](https://img.shields.io/npm/v/@marp-team/marpit.svg?style=flat-square&label=%20&colorA=transparent&colorB=888)](https://www.npmjs.com/package/@marp-team/marpit)
+- [![npm](https://icongr.am/material/npm.svg?size=24&color=808080)npm ![](https://img.shields.io/npm/v/@marp-team/marpit.svg?style=flat-square&label=&colorB=888)](https://www.npmjs.com/package/@marp-team/marpit)


### PR DESCRIPTION
The spacing around a version badge in docs sidebar is no longer appeared by change of [Shields.io](https://shields.io/) rendering implementation. By this PR's change, the badge in docs will get to look well.