### PR TITLE
Fix remaining orphan break by sweeping hidden inline token forcibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix remaining orphan break by sweeping hidden inline token forcibly ([#114](https://github.com/marp-team/marpit/pull/114))
+
 ## v0.4.1 - 2018-12-18
 
 ### Fixed

--- a/src/markdown/sweep.js
+++ b/src/markdown/sweep.js
@@ -7,6 +7,9 @@
  * directives through HTML comment, Marpit will sweep paragraphs included only
  * whitespace by setting `hidden: true`.
  *
+ * It also sweep the inline token marked as hidden forcely. Please notice that
+ * plugins executed after this cannot handle hidden inline tokens.
+ *
  * @alias module:markdown/sweep
  * @param {MarkdownIt} md markdown-it instance.
  */
@@ -31,7 +34,11 @@ function sweep(md) {
     const current = { open: [], tokens: {} }
 
     for (const token of state.tokens) {
-      if (token.type === 'paragraph_open') {
+      if (token.type === 'inline' && token.hidden) {
+        // markdown-it's "inline" type is not following a `hidden` flag. Marpit
+        // changes the token type to unique name to hide token forcely.
+        token.type = 'marpit_hidden_inline'
+      } else if (token.type === 'paragraph_open') {
         current.open.push(token)
         current.tokens[token] = []
       } else if (token.type === 'paragraph_close') {

--- a/test/markdown/sweep.js
+++ b/test/markdown/sweep.js
@@ -22,7 +22,7 @@ describe('Marpit sweep plugin', () => {
       options: { inlineSVG: false },
     }
 
-    const markdown = md()
+    const markdown = md({ breaks: true })
       .use(slide)
       .use(parseDirectives, marpitStub)
       .use(applyDirectives)
@@ -46,6 +46,7 @@ describe('Marpit sweep plugin', () => {
     )
 
     expect($('p')).toHaveLength(2)
+    expect($('br')).toHaveLength(0)
   })
 
   const htmlOptions = [true, false]


### PR DESCRIPTION
I've found that the sweep plugin does not handle the HTML breaks rendered when markdown-it's `breaks` option is enabled. markdown-it does not treat `hidden` flag for `inline` token.

```markdown
![bg](https://github.com/yhatt.png)
![bg](https://github.com/marp-team.png)

# Hello
```

<img width="443" alt="Unexpected orphan break" src="https://user-images.githubusercontent.com/3993388/50421647-148d7c00-0885-11e9-8023-6a8907899d8c.png">

It causes by the behavior of markdown-it. The inline token is not treat `hidden` flag.

Marpit sweep plugin will rename the token type into unique name: `marpit_hidden_inline`. `hidden: true` becomes to work for unknown tokens, so we can sweep hidden inline token forcibly.