### PR TITLE
Add data-marpit-svg attribute to SVG element outputted by inline SVG mode

### DIFF
--- a/docs/inline-svg.md
+++ b/docs/inline-svg.md
@@ -5,12 +5,12 @@
 When you set [`inlineSVG: true` in Marpit constructor option](/usage#triangular_ruler-inline-svg-slide), each `<section>` elements are wrapped with inline SVG.
 
 ```html
-<svg viewBox="0 0 1280 960">
+<svg data-marpit-svg="" viewBox="0 0 1280 960">
   <foreignObject width="1280" height="960">
     <section><h1>Page 1</h1></section>
   </foreignObject>
 </svg>
-<svg viewBox="0 0 1280 960">
+<svg data-marpit-svg="" viewBox="0 0 1280 960">
   <foreignObject width="1280" height="960">
     <section><h1>Page 2</h1></section>
   </foreignObject>
@@ -27,7 +27,7 @@ You may delegate a logic of pixel-perfect scaling for slide page to SVG. You hav
 
 ```css
 /* Fit slide page to viewport */
-svg {
+svg[data-marpit-svg] {
   display: block;
   width: 100vw;
   height: 100vh;

--- a/src/markdown/inline_svg.js
+++ b/src/markdown/inline_svg.js
@@ -33,6 +33,7 @@ function inlineSVG(md, marpit) {
             'marpit_inline_svg',
             {
               tag: 'svg',
+              'data-marpit-svg': '',
               viewBox: `0 0 ${w} ${h}`,
               open: { meta: { marpitSlideElement: 1 } },
               close: { meta: { marpitSlideElement: -1 } },

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -56,7 +56,7 @@ section[data-marpit-advanced-background="pseudo"] {
 }
 
 section[data-marpit-advanced-background="pseudo"],
-:marpit-container > svg > foreignObject[data-marpit-advanced-background="pseudo"] {
+:marpit-container > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"] {
   pointer-events: none !important;
 }
 

--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -41,7 +41,7 @@ const plugin = postcss.plugin('marpit-postcss-printable', opts => css => {
     color-adjust: exact !important;
   }
 
-  :marpit-container > svg {
+  :marpit-container > svg[data-marpit-svg] {
     display: block;
     height: 100vh;
     width: 100vw;

--- a/test/markdown/inline_svg.js
+++ b/test/markdown/inline_svg.js
@@ -34,7 +34,9 @@ describe('Marpit inline SVG plugin', () => {
     const $ = render(md(), '# test\n\n---\n\n# test')
 
     expect(
-      $('svg[viewBox] > foreignObject[width][height] > section')
+      $(
+        'svg[viewBox][data-marpit-svg] > foreignObject[width][height] > section'
+      )
     ).toHaveLength(2)
   })
 


### PR DESCRIPTION
To be available selecting wrapped SVG by CSS query, we added data-marpit-svg attribute to SVG element outputted by inline SVG mode.

It would be used in [marpit-svg-webkit-polyfill](https://github.com/marp-team/marpit-svg-webkit-polyfill), to resolve the rendering bug in WebKit.

```html
<svg data-marpit-svg="" viewBox="0 0 1280 960">
  <foreignObject width="1280" height="960">
    <section>
      ...
    </section>
  </foreignObject>
</svg>
```

