### PR TITLE
Update docs to explain SVG slide polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Update docs to explain SVG slide polyfill ([#117](https://github.com/marp-team/marpit/pull/117))
+
 ## v0.5.0 - 2018-12-28
 
 ### Added

--- a/docs/inline-svg.md
+++ b/docs/inline-svg.md
@@ -61,7 +61,7 @@ Marpit's [advanced backgrounds](/image-syntax#advanced-backgrounds) would work w
 
 ## Polyfill
 
-We provide a [polyfill](#polyfill) for WebKit based browsers in [@marp-team/marpit-svg-polyfill](https://github.com/marp-team/marpit-svg-polyfill).
+We provide a polyfill for WebKit based browsers in [@marp-team/marpit-svg-polyfill](https://github.com/marp-team/marpit-svg-polyfill).
 
 ```html
 <svg data-marpit-svg viewBox="0 0 1280 960">

--- a/docs/inline-svg.md
+++ b/docs/inline-svg.md
@@ -5,12 +5,12 @@
 When you set [`inlineSVG: true` in Marpit constructor option](/usage#triangular_ruler-inline-svg-slide), each `<section>` elements are wrapped with inline SVG.
 
 ```html
-<svg data-marpit-svg="" viewBox="0 0 1280 960">
+<svg data-marpit-svg viewBox="0 0 1280 960">
   <foreignObject width="1280" height="960">
     <section><h1>Page 1</h1></section>
   </foreignObject>
 </svg>
-<svg data-marpit-svg="" viewBox="0 0 1280 960">
+<svg data-marpit-svg viewBox="0 0 1280 960">
   <foreignObject width="1280" height="960">
     <section><h1>Page 2</h1></section>
   </foreignObject>
@@ -36,16 +36,40 @@ svg[data-marpit-svg] {
 
 Developer can handle the slide much easier in Marpit integrated apps.
 
-!> WebKit cannot scale HTML elements in `<foreignObject>`. ([Bug 23113](https://bugs.webkit.org/show_bug.cgi?id=23113)) Blink can scale them, but currently layouting seems not to be stable. ([Bug 467484](https://bugs.chromium.org/p/chromium/issues/detail?id=467484))
+> [@marp-team/marp-core](https://github.com/marp-team/marp-core), has extended from Marpit, has [useful auto-scaling features](https://github.com/marp-team/marp-core#auto-scaling-features) that are taken this advantage.
 
-?> [@marp-team/marp-core](https://github.com/marp-team/marp-core), has extended from Marpit, has [useful auto-scaling features](https://github.com/marp-team/marp-core#auto-scaling-features) that are applied this feature.
+!> WebKit cannot scale HTML elements in `<foreignObject>` ([Bug 23113](https://bugs.webkit.org/show_bug.cgi?id=23113): It can mitigate by [polyfill](#polyfill)). Blink can scale them, but currently layouting seems not to be stable ([Bug 467484](https://bugs.chromium.org/p/chromium/issues/detail?id=467484)).
 
 ### No require JavaScript
 
 Marpit's scaffold style has defined `scroll-snap-align` declaration to `section` elements. They can align and fit to viewport by defining `scroll-snap-type` to the scroll container. ([CSS Scroll Snap](https://developers.google.com/web/updates/2018/07/css-scroll-snap))
 
-Thus, a minimal web-based presentation no longer requires JavaScript.
+Thus, a minimal web-based presentation no longer requires JavaScript. We strongly believe that keeping logic-less is important for performance and maintaining framework.
+
+> By using Marpit, [@marp-team/marp-cli](https://github.com/marp-team/marp-cli) can output HTML file for presentation that is consisted of _only HTML and CSS_.
+>
+> ```bash
+> npm i -g @marp-team/marp-cli
+> npm i @marp-team/marpit
+>
+> marp --template bare --engine @marp-team/marpit marpit-deck.md
+> ```
 
 ### Isolated layer
 
 Marpit's [advanced backgrounds](/image-syntax#advanced-backgrounds) would work within the isolated `<foreignObject>` from the content. It means that the original Markdown DOM structure per page are keeping.
+
+## Polyfill
+
+We provide a [polyfill](#polyfill) for WebKit based browsers in [@marp-team/marpit-svg-polyfill](https://github.com/marp-team/marpit-svg-polyfill).
+
+```html
+<svg data-marpit-svg viewBox="0 0 1280 960">
+  <foreignObject width="1280" height="960">
+    <section><h1>Page 1</h1></section>
+  </foreignObject>
+</svg>
+
+<!-- Apply polyfill -->
+<script src="https://cdn.jsdelivr.net/npm/@marp-team/marpit-svg-polyfill/lib/polyfill.browser.js"></script>
+```


### PR DESCRIPTION
Recently we have created [@marp-team/marpit-svg-polyfill](https://github.com/marp-team/marpit-svg-polyfill) to fix rendering bug in WebKit based browser, and it is working well in Safari and iOS browsers! This PR adds the usage of polyfill to docs.

Some users might think that it have to implement in inside of Marpit. We also modified about docs of zero-JS feature for making our position clear. By splitting polyfill into another module, we can keep zero-JS and provide it only to required user.
