### PR TITLE
Add env argument to render method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add `env` argument to [`Marpit.render()`](https://marpit-api.marp.app/marpit#render) ([#118](https://github.com/marp-team/marpit/pull/118))
 - Update docs to explain SVG slide polyfill ([#117](https://github.com/marp-team/marpit/pull/117))
 
 ## v0.5.0 - 2018-12-28

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module '@marp-team/marpit' {
     protected lastGlobalDirectives?: { [directive: string]: any }
     protected lastStyles?: string[]
 
-    render(markdown: string): MarpitRenderResult
+    render(markdown: string, env?: any): MarpitRenderResult
     use<P extends any[]>(
       plugin: (
         this: Marpit['markdown'],
@@ -53,7 +53,7 @@ declare module '@marp-team/marpit' {
     ): this
 
     protected applyMarkdownItPlugins(md: any): void
-    protected renderMarkdown(markdown: string): string
+    protected renderMarkdown(markdown: string, env?: any): string
     protected renderStyle(theme?: string): string
     protected themeSetPackOptions(): ThemeSetPackOptions
   }

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -147,11 +147,12 @@ class Marpit {
    * Render Markdown into HTML and CSS string.
    *
    * @param {string} markdown A Markdown string.
+   * @param {Object} [env] Environment object for passing to markdown-it.
    * @returns {Marpit~RenderResult} An object of rendering result.
    */
-  render(markdown) {
+  render(markdown, env = {}) {
     return {
-      html: this.renderMarkdown(markdown),
+      html: this.renderMarkdown(markdown, env),
       css: this.renderStyle(this.lastGlobalDirectives.theme),
       comments: this.lastComments,
     }
@@ -165,10 +166,11 @@ class Marpit {
    *
    * @private
    * @param {string} markdown A Markdown string.
+   * @param {Object} [env] Environment object for passing to markdown-it.
    * @returns {string} The result string of rendering Markdown.
    */
-  renderMarkdown(markdown) {
-    return this.markdown.render(markdown)
+  renderMarkdown(markdown, env = {}) {
+    return this.markdown.render(markdown, env)
   }
 
   /**

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -82,6 +82,16 @@ describe('Marpit', () => {
       })
     })
 
+    context('with env argument', () => {
+      it('passes env option to markdown#render', () => {
+        const instance = new Marpit()
+        const render = jest.spyOn(instance.markdown, 'render')
+
+        instance.render('Markdown', { env: 'env' })
+        expect(render).toBeCalledWith('Markdown', { env: 'env' })
+      })
+    })
+
     context('with inlineSVG option', () => {
       const instance = inlineSVG => {
         const marpit = new Marpit({ inlineSVG })
@@ -252,9 +262,10 @@ describe('Marpit', () => {
   describe('#renderMarkdown', () => {
     it('returns the result of markdown#render', () => {
       const instance = new Marpit()
-      instance.markdown.render = md => `test of ${md}`
+      const spy = jest.spyOn(instance.markdown, 'render').mockImplementation()
 
-      expect(instance.renderMarkdown('render')).toBe('test of render')
+      instance.renderMarkdown('render', { env: 'env' })
+      expect(spy).toBeCalledWith('render', { env: 'env' })
     })
   })
 


### PR DESCRIPTION
To make compatibility with [markdown-it's `render` method](https://markdown-it.github.io/markdown-it/#MarkdownIt.render), we added `env` argument to pass into `Marpit.render()`.

We need this for #112, to output the slide deck as array.

```javascript
marpit.render('# Markdown', { outputAsArray: true })
```