### PR TITLE
Include inline SVG elements when rendered with htmlAsArray env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Include inline SVG elements when rendered with `htmlAsArray` env ([#123](https://github.com/marp-team/marpit/pull/123))
+
 ### Changed
 
 - Small update for README and docs ([#122](https://github.com/marp-team/marpit/pull/122))

--- a/src/markdown/collect.js
+++ b/src/markdown/collect.js
@@ -20,6 +20,7 @@ function collect(md, marpit) {
     marpit.lastSlideTokens = []
 
     let currentPage
+    let pageIdx = -1
 
     const collectComment = token => {
       if (
@@ -33,21 +34,15 @@ function collect(md, marpit) {
       currentPage >= 0 && marpit.lastSlideTokens[currentPage] !== undefined
 
     for (const token of state.tokens) {
-      if (
-        token.type === 'marpit_slide_open' &&
-        token.meta &&
-        token.meta.marpitSlide !== undefined
-      ) {
-        currentPage = token.meta.marpitSlide
+      if (token.meta && token.meta.marpitSlideElement === 1) {
+        pageIdx += 1
+        currentPage = pageIdx
 
-        if (
-          currentPage >= 0 &&
-          marpit.lastSlideTokens[currentPage] === undefined
-        ) {
+        if (marpit.lastSlideTokens[currentPage] === undefined) {
           marpit.lastSlideTokens[currentPage] = [token]
           marpit.lastComments[currentPage] = []
         }
-      } else if (token.type === 'marpit_slide_close') {
+      } else if (token.meta && token.meta.marpitSlideElement === -1) {
         if (collectable()) marpit.lastSlideTokens[currentPage].push(token)
         currentPage = undefined
       } else {

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -141,6 +141,16 @@ describe('Marpit', () => {
             expect(countDecl(ret.root, '--theme-defined')).toBe(1)
           })
       })
+
+      context('when passed htmlAsArray env', () => {
+        it('outputs HTML including inline SVG as array', () => {
+          const { html } = instance(true).render('# Hi', { htmlAsArray: true })
+          expect(html).toHaveLength(1)
+
+          const $ = cheerio.load(html[0], { lowerCaseTags: false })
+          expect($('svg > foreignObject')).toHaveLength(1)
+        })
+      })
     })
 
     context('with backgroundSyntax option', () => {


### PR DESCRIPTION
When rendered Markdown with `htmlAsArray` env (#119) and inline SVG mode, the output array does not include SVG elements. `htmlAsArray` should include all rendered elements excepted containers.