### PR TITLE
Custom directives support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Make custom directives definable via `customDirectives` property ([#124](https://github.com/marp-team/marpit/issues/124), [#125](https://github.com/marp-team/marpit/pull/125))
+
 ## v0.6.1 - 2019-01-25
 
 ### Fixed

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -8,17 +8,23 @@ import InlineStyle from '../../helpers/inline_style'
  *
  * @alias module:markdown/directives/apply
  * @param {MarkdownIt} md markdown-it instance.
+ * @param {Marpit} marpit Marpit instance.
  * @param {Object} [opts]
  * @param {boolean} [opts.dataset=true] Assigns directives as HTML data
  *     attributes of each section tag.
- * @param {string[]} [opts.directives] Assignable custom directive keys.
  * @param {boolean} [opts.css=true] Assigns directives as CSS Custom Properties
  *     of each section tag.
  */
-function apply(md, opts = {}) {
+function apply(md, marpit, opts = {}) {
   const dataset = opts.dataset === undefined ? true : !!opts.dataset
-  const directives = [...(opts.directives || []), ...builtInDirectives]
   const css = opts.css === undefined ? true : !!opts.css
+
+  const { global, local } = marpit.customDirectives
+  const directives = [
+    ...Object.keys(global),
+    ...Object.keys(local),
+    ...builtInDirectives,
+  ]
 
   md.core.ruler.after(
     'marpit_directives_parse',

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -1,9 +1,7 @@
 /** @module */
 import kebabCase from 'lodash.kebabcase'
-import { globals, locals } from './directives'
+import builtInDirectives from './directives'
 import InlineStyle from '../../helpers/inline_style'
-
-const publicDirectives = [...Object.keys(globals), ...Object.keys(locals)]
 
 /**
  * Apply parsed Marpit directives to markdown-it tokens.
@@ -13,18 +11,14 @@ const publicDirectives = [...Object.keys(globals), ...Object.keys(locals)]
  * @param {Object} [opts]
  * @param {boolean} [opts.dataset=true] Assigns directives as HTML data
  *     attributes of each section tag.
+ * @param {string[]} [opts.directives] Assignable custom directive keys.
  * @param {boolean} [opts.css=true] Assigns directives as CSS Custom Properties
  *     of each section tag.
- * @param {boolean} [opts.includeInternal=false] Whether include internal
- *     directives (Undefined in {@link module:markdown/directives/directives}.)
- *     In default, internal directives are not applied to HTML/CSS.
  */
 function apply(md, opts = {}) {
   const dataset = opts.dataset === undefined ? true : !!opts.dataset
+  const directives = [...(opts.directives || []), ...builtInDirectives]
   const css = opts.css === undefined ? true : !!opts.css
-
-  const filterFunc = key =>
-    !!opts.includeInternal || publicDirectives.includes(key)
 
   md.core.ruler.after(
     'marpit_directives_parse',
@@ -39,7 +33,7 @@ function apply(md, opts = {}) {
           const style = new InlineStyle(token.attrGet('style'))
 
           for (const dir of Object.keys(marpitDirectives)) {
-            if (filterFunc(dir)) {
+            if (directives.includes(dir)) {
               const value = marpitDirectives[dir]
 
               if (value) {

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -24,7 +24,7 @@
  * @prop {Directive} theme Specify theme of the slide deck.
  */
 export const globals = {
-  headingDivider(value) {
+  headingDivider: value => {
     const headings = [1, 2, 3, 4, 5, 6]
     const toInt = v =>
       Array.isArray(v) || Number.isNaN(v) ? v : Number.parseInt(v, 10)
@@ -42,13 +42,8 @@ export const globals = {
 
     return {}
   },
-  style(value) {
-    return { style: value }
-  },
-  theme(value, marpit) {
-    if (!marpit.themeSet.has(value)) return {}
-    return { theme: value }
-  },
+  style: v => ({ style: v }),
+  theme: (v, marpit) => (marpit.themeSet.has(v) ? { theme: v } : {}),
 }
 
 /**
@@ -77,38 +72,16 @@ export const globals = {
  * @prop {Directive} paginate Show page number on the slide if you set `true`.
  */
 export const locals = {
-  backgroundColor(value) {
-    return { backgroundColor: value }
-  },
-  backgroundImage(value) {
-    return { backgroundImage: value }
-  },
-  backgroundPosition(value) {
-    return { backgroundPosition: value }
-  },
-  backgroundRepeat(value) {
-    return { backgroundRepeat: value }
-  },
-  backgroundSize(value) {
-    return { backgroundSize: value }
-  },
-  class(value) {
-    return { class: Array.isArray(value) ? value.join(' ') : value }
-  },
-  color(value) {
-    return { color: value }
-  },
-  footer(value) {
-    return typeof value === 'string' ? { footer: value } : {}
-  },
-  header(value) {
-    return typeof value === 'string' ? { header: value } : {}
-  },
-  paginate(value) {
-    return { paginate: (value || '').toLowerCase() === 'true' }
-  },
+  backgroundColor: v => ({ backgroundColor: v }),
+  backgroundImage: v => ({ backgroundImage: v }),
+  backgroundPosition: v => ({ backgroundPosition: v }),
+  backgroundRepeat: v => ({ backgroundRepeat: v }),
+  backgroundSize: v => ({ backgroundSize: v }),
+  class: v => ({ class: Array.isArray(v) ? v.join(' ') : v }),
+  color: v => ({ color: v }),
+  footer: v => (typeof v === 'string' ? { footer: v } : {}),
+  header: v => (typeof v === 'string' ? { header: v } : {}),
+  paginate: v => ({ paginate: (v || '').toLowerCase() === 'true' }),
 }
 
-const directiveNames = [...Object.keys(globals), ...Object.keys(locals)]
-
-export default directiveNames
+export default [...Object.keys(globals), ...Object.keys(locals)]

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -1,7 +1,7 @@
 /** @module */
 import MarkdownItFrontMatter from 'markdown-it-front-matter'
 import yaml from './yaml'
-import { globals, locals } from './directives'
+import * as directives from './directives'
 
 /**
  * Parse Marpit directives and store result to the slide token meta.
@@ -16,9 +16,14 @@ import { globals, locals } from './directives'
  * @param {boolean} [opts.frontMatter=true] Switch feature to support YAML
  *     front-matter. If true, you can use Jekyll style directive setting to the
  *     first page.
+ * @param {Object} [opts.global] Define custom global directives.
+ * @param {Object} [opts.local] Define custom local directives.
  * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
  */
 function parse(md, marpit, opts = {}) {
+  const globals = { ...(opts.global || {}), ...directives.globals }
+  const locals = { ...(opts.local || {}), ...directives.locals }
+
   // Front-matter support
   const frontMatter = opts.frontMatter === undefined ? true : !!opts.frontMatter
   let frontMatterObject = {}

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -21,6 +21,7 @@ import marpitSweep from './markdown/sweep'
 const defaultOptions = {
   backgroundSyntax: true,
   container: marpitContainer,
+  directives: {},
   filters: true,
   headingDivider: false,
   inlineStyle: true,
@@ -44,6 +45,10 @@ class Marpit {
    *     with the alternate text including `bg`. Normally it converts into spot
    *     directives about background image. If `inlineSVG` is enabled, it
    *     supports the advanced backgrounds.
+   * @param {Object} [opts.directives] Define custom directives to parser. The
+   *     parsed result can access through markdown-it's parsed token meta.
+   * @param {Object} [opts.directives.global]
+   * @param {Object} [opts.directives.local]
    * @param {false|Element|Element[]}
    *     [opts.container={@link module:element.marpitContainer}] Container
    *     element(s) wrapping whole slide deck.
@@ -115,13 +120,29 @@ class Marpit {
 
   /** @private */
   applyMarkdownItPlugins(md = this.markdown) {
-    const { backgroundSyntax, filters, looseYAML, scopedStyle } = this.options
+    const {
+      backgroundSyntax,
+      directives,
+      filters,
+      looseYAML,
+      scopedStyle,
+    } = this.options
+
+    const customDirectives = {
+      global: (directives && directives.global) || {},
+      local: (directives && directives.local) || {},
+    }
+
+    const customDirectiveList = [
+      ...Object.keys(customDirectives.global),
+      ...Object.keys(customDirectives.local),
+    ]
 
     md.use(marpitComment, { looseYAML })
       .use(marpitStyleParse, this)
       .use(marpitSlide)
-      .use(marpitParseDirectives, this, { looseYAML })
-      .use(marpitApplyDirectives)
+      .use(marpitParseDirectives, this, { ...customDirectives, looseYAML })
+      .use(marpitApplyDirectives, { directives: customDirectiveList })
       .use(marpitHeaderAndFooter)
       .use(marpitHeadingDivider, this)
       .use(marpitSlideContainer, this.slideContainers)

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -133,14 +133,12 @@ class Marpit {
   /** @private */
   applyMarkdownItPlugins(md = this.markdown) {
     const { backgroundSyntax, filters, looseYAML, scopedStyle } = this.options
-    const { global, local } = this.customDirectives
-    const customDirectiveList = [...Object.keys(global), ...Object.keys(local)]
 
     md.use(marpitComment, { looseYAML })
       .use(marpitStyleParse, this)
       .use(marpitSlide)
-      .use(marpitParseDirectives, this, { ...this.customDirectives, looseYAML })
-      .use(marpitApplyDirectives, { directives: customDirectiveList })
+      .use(marpitParseDirectives, this, { looseYAML })
+      .use(marpitApplyDirectives, this)
       .use(marpitHeaderAndFooter)
       .use(marpitHeadingDivider, this)
       .use(marpitSlideContainer, this.slideContainers)

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -12,6 +12,7 @@ const splitBackgroundKeywords = ['left', 'right']
 
 describe('Marpit background image plugin', () => {
   const marpitStub = svg => ({
+    customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
     themeSet: { getThemeProp: () => 100 },
     options: { inlineSVG: svg },
@@ -22,7 +23,7 @@ describe('Marpit background image plugin', () => {
       .use(comment)
       .use(slide)
       .use(parseDirectives, marpitStub(svg))
-      .use(applyDirectives)
+      .use(applyDirectives, marpitStub(svg))
       .use(inlineSVG, marpitStub(svg))
       .use(parseImage, { filters })
       .use(backgroundImage)

--- a/test/markdown/collect.js
+++ b/test/markdown/collect.js
@@ -13,6 +13,7 @@ describe('Marpit collect plugin', () => {
 
   const marpitStub = (svg = false) => ({
     themeSet,
+    customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
     options: { inlineSVG: svg },
   })
@@ -21,8 +22,11 @@ describe('Marpit collect plugin', () => {
     new MarkdownIt('commonmark')
       .use(comment)
       .use(slide)
-      .use(parseDirectives, { themeSet: marpitInstance.themeSet })
-      .use(applyDirectives)
+      .use(parseDirectives, {
+        customDirectives: marpitInstance.customDirectives,
+        themeSet: marpitInstance.themeSet,
+      })
+      .use(applyDirectives, marpitInstance)
       .use(collect, marpitInstance)
       .use(inlineSVG, marpitInstance)
 

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -86,19 +86,6 @@ describe('Marpit directives apply plugin', () => {
     })
   })
 
-  context('with includeInternal option as true', () => {
-    const opts = { includeInternal: true }
-
-    it('applies together with unknown (internal) directive', () => {
-      const $ = cheerio.load(mdForTest(opts).render(basicDirs))
-      const section = $('section').first()
-      const style = toObjStyle(section.attr('style'))
-
-      expect(section.attr('data-unknown-dir')).toBe('directive')
-      expect(style['--unknown-dir']).toBe('directive')
-    })
-  })
-
   describe('Local directives', () => {
     describe('Background image', () => {
       const bgDirs = dedent`

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -10,12 +10,15 @@ describe('Marpit directives apply plugin', () => {
   const themeSetStub = new Map()
   themeSetStub.set('test_theme', true)
 
-  const md = (...args) =>
-    new MarkdownIt('commonmark')
+  const md = (...args) => {
+    const customDirectives = { global: {}, local: {} }
+
+    return new MarkdownIt('commonmark')
       .use(comment)
       .use(slide)
-      .use(parseDirectives, { themeSet: themeSetStub })
-      .use(applyDirectives, ...args)
+      .use(parseDirectives, { customDirectives, themeSet: themeSetStub })
+      .use(applyDirectives, { customDirectives }, ...args)
+  }
 
   const mdForTest = (...args) =>
     md(...args).use(mdInstance => {

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -6,7 +6,10 @@ import slide from '../../../src/markdown/slide'
 
 describe('Marpit directives parse plugin', () => {
   const themeSetStub = new Map()
-  const marpitStub = { themeSet: themeSetStub }
+  const marpitStub = {
+    customDirectives: { global: {}, local: {} },
+    themeSet: themeSetStub,
+  }
   themeSetStub.set('test_theme', true)
 
   const md = (...args) =>

--- a/test/markdown/header_and_footer.js
+++ b/test/markdown/header_and_footer.js
@@ -12,6 +12,7 @@ describe('Marpit header and footer plugin', () => {
 
   const marpitStub = (props = {}) => ({
     themeSet,
+    customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
     ...props,
   })
@@ -20,8 +21,11 @@ describe('Marpit header and footer plugin', () => {
     new MarkdownIt('commonmark')
       .use(comment)
       .use(slide)
-      .use(parseDirectives, { themeSet: marpitInstance.themeSet })
-      .use(applyDirectives)
+      .use(parseDirectives, {
+        customDirectives: marpitInstance.customDirectives,
+        themeSet: marpitInstance.themeSet,
+      })
+      .use(applyDirectives, marpitInstance)
       .use(headerAndFooter)
 
   describe('Header local directive', () => {

--- a/test/markdown/heading_divider.js
+++ b/test/markdown/heading_divider.js
@@ -7,6 +7,7 @@ import slide from '../../src/markdown/slide'
 
 describe('Marpit heading divider plugin', () => {
   const marpitStub = headingDividerOption => ({
+    customDirectives: { global: {}, local: {} },
     options: { headingDivider: headingDividerOption },
   })
 
@@ -106,7 +107,12 @@ describe('Marpit heading divider plugin', () => {
   })
 
   describe('Global directive', () => {
-    const md = (marpitInstance = { options: {} }) =>
+    const md = (
+      marpitInstance = {
+        customDirectives: { global: {}, local: {} },
+        options: {},
+      }
+    ) =>
       new MarkdownIt('commonmark')
         .use(comment)
         .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))

--- a/test/markdown/inline_svg.js
+++ b/test/markdown/inline_svg.js
@@ -8,6 +8,7 @@ import { Theme, ThemeSet } from '../../src/index'
 
 describe('Marpit inline SVG plugin', () => {
   const marpitStub = (props = {}) => ({
+    customDirectives: { global: {}, local: {} },
     themeSet: new ThemeSet(),
     lastGlobalDirectives: {},
     options: { inlineSVG: true },
@@ -17,8 +18,11 @@ describe('Marpit inline SVG plugin', () => {
   const md = (marpitInstance = marpitStub()) =>
     new MarkdownIt('commonmark')
       .use(slide)
-      .use(parseDirectives, { themeSet: marpitInstance.themeSet })
-      .use(applyDirectives)
+      .use(parseDirectives, {
+        customDirectives: marpitInstance.customDirectives,
+        themeSet: marpitInstance.themeSet,
+      })
+      .use(applyDirectives, marpitInstance)
       .use(inlineSVG, marpitInstance)
 
   const render = (markdownIt, text, inline = false) => {

--- a/test/markdown/style/assign.js
+++ b/test/markdown/style/assign.js
@@ -10,6 +10,7 @@ import styleParse from '../../../src/markdown/style/parse'
 
 describe('Marpit style assign plugin', () => {
   const marpitStub = (...opts) => ({
+    customDirectives: { global: {}, local: {} },
     options: { inlineStyle: true },
     themeSet: new Map(),
     ...opts,
@@ -109,7 +110,7 @@ describe('Marpit style assign plugin', () => {
         .use(comment)
         .use(slide)
         .use(parseDirectives, marpit)
-        .use(applyDirectives)
+        .use(applyDirectives, marpit)
         .use(styleAssign, marpit)
 
     it('assigns parsed style global directive to Marpit lastStyles property', () => {
@@ -131,7 +132,7 @@ describe('Marpit style assign plugin', () => {
         .use(styleParse, marpit)
         .use(slide)
         .use(parseDirectives, marpit)
-        .use(applyDirectives)
+        .use(applyDirectives, marpit)
         .use(styleAssign, marpit)
 
     it('assigns inline styles prior to directive style', () => {

--- a/test/markdown/sweep.js
+++ b/test/markdown/sweep.js
@@ -18,6 +18,7 @@ describe('Marpit sweep plugin', () => {
 
   it('sweeps blank paragraph made by background image plugin', () => {
     const marpitStub = {
+      customDirectives: { global: {}, local: {} },
       themeSet: new Map(),
       options: { inlineSVG: false },
     }
@@ -25,7 +26,7 @@ describe('Marpit sweep plugin', () => {
     const markdown = md({ breaks: true })
       .use(slide)
       .use(parseDirectives, marpitStub)
-      .use(applyDirectives)
+      .use(applyDirectives, marpitStub)
       .use(inlineSVG, marpitStub)
       .use(parseImage)
       .use(backgroundImage)


### PR DESCRIPTION
Add `Marpit.customDirectives` property to define custom directives per instance. It resolves #124.

This object has the assignable `global` and `local` object. By defining the parser function to each object, Marpit would recognize additional directives. The parser should return the validated object that includes new value(s) for updating meta of markdown-it token.

The built-in directive parsers cannot overload by custom directives. The name of built-in directives cannot assign as new meta value too.

Currently, we do not intend to document about custom directives at https://marpit.marp.app/, because it will only affect internal tokens.

We will use that in the future VSCode plugin of Marp.  Marp slide deck would be able to preview when `marp: true` is defined in front-matter. See yhatt/marp#118.

```javascript
const marpit = new Marpit()
marpit.customDirectives.global.marp = v => ({ marp: v === 'true' })
```