### PR TITLE
Use CSS Fragmentation to control page break

### DIFF
--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -6,6 +6,7 @@ html, body {
   background-color: #fff;
   margin: 0;
   page-break-inside: avoid;
+  break-inside: avoid-page;
 }
 `.trim()
 
@@ -34,6 +35,7 @@ const plugin = postcss.plugin('marpit-postcss-printable', opts => css => {
 @media marpit-print {
   section {
     page-break-before: always;
+    break-before: page;
   }
 
   section, section * {

--- a/test/postcss/printable.js
+++ b/test/postcss/printable.js
@@ -39,6 +39,7 @@ describe('Marpit PostCSS printable plugin', () => {
       for (const tag of ['html', 'body']) {
         const r = findRule(print, { selectors: s => s.includes(tag) })
         expect(findDecl(r, { prop: 'page-break-inside' }).value).toBe('avoid')
+        expect(findDecl(r, { prop: 'break-inside' }).value).toBe('avoid-page')
         expect(findDecl(r, { prop: 'margin' }).value).toBe('0')
       }
 


### PR DESCRIPTION
[By upon receipt scheduled Firefox 65](https://bugzilla.mozilla.org/show_bug.cgi?id=775618), the all modern browsers will alias `page-break-*` CSS property to `break-*` specified in [CSS fragmentation](https://drafts.csswg.org/css-break-3/). 

Thus, we updated Marpit printable plugin to use CSS fragmentation for controlling page break. The added properties will affect only to the print pages.