### PR TITLE
Enhance plugin system to control Marpit features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Make custom directives definable via `customDirectives` member ([#124](https://github.com/marp-team/marpit/issues/124), [#125](https://github.com/marp-team/marpit/pull/125), [#128](https://github.com/marp-team/marpit/pull/128))
+- Enhance plugin system to control Marpit features ([#127](https://github.com/marp-team/marpit/pull/127))
 
 ### Changed
 

--- a/src/helpers/plugin.js
+++ b/src/helpers/plugin.js
@@ -1,0 +1,82 @@
+/**
+ * @module
+ */
+
+const usingMarpit = Symbol('usingMarpit')
+export const disabledMarpitSymbol = Symbol('disabledMarpit')
+
+function onInitializeStateCore(state) {
+  state.md[disabledMarpitSymbol] = false
+
+  state.disableMarpit = function disableMarpit(value = true) {
+    state.md[disabledMarpitSymbol] = value
+  }
+}
+
+function ruleWrapper(basePlugin) {
+  return function wrappedRule(state, ...args) {
+    if (state.md[disabledMarpitSymbol]) return false
+
+    return basePlugin(state, ...args)
+  }
+}
+
+/**
+ * Enhance markdown-it plugin system to support Marpit.
+ *
+ * @alias module:helpers/plugin
+ * @param {MarkdownIt} md markdown-it instance.
+ * @param {Function} callback Callback function. markdown-it rules extended
+ *     within the callback will check the disabled state of Marpit.
+ */
+function useMarpitPlugin(md, callback) {
+  if (!md[usingMarpit]) {
+    md[usingMarpit] = true
+
+    const { State } = md.core
+
+    md.core.State = function StateCore(src, markdownIt, env) {
+      const state = new State(src, markdownIt, env)
+
+      onInitializeStateCore(state)
+      return state
+    }
+  }
+
+  const ruler = Object.getPrototypeOf(md.core.ruler)
+  const { after, at, before, push } = ruler
+
+  const resetRuler = () => {
+    ruler.after = after
+    ruler.at = at
+    ruler.before = before
+    ruler.push = push
+  }
+
+  try {
+    ruler.after = function marpitAfter(afterName, ruleName, fn, options) {
+      return after.call(this, afterName, ruleName, ruleWrapper(fn), options)
+    }
+
+    ruler.at = function marpitAt(name, fn, options) {
+      return at.call(this, name, ruleWrapper(fn), options)
+    }
+
+    ruler.before = function marpitBefore(beforeName, ruleName, fn, options) {
+      return before.call(this, beforeName, ruleName, ruleWrapper(fn), options)
+    }
+
+    ruler.push = function marpitPush(ruleName, fn, options) {
+      return push.call(this, ruleName, ruleWrapper(fn), options)
+    }
+
+    callback()
+  } catch (e) {
+    resetRuler()
+    throw e
+  }
+
+  resetRuler()
+}
+
+export default useMarpitPlugin

--- a/src/helpers/plugin.js
+++ b/src/helpers/plugin.js
@@ -2,20 +2,19 @@
  * @module
  */
 
-const usingMarpit = Symbol('usingMarpit')
-export const disabledMarpitSymbol = Symbol('disabledMarpit')
+export const MarpitSymbol = Symbol('Marpit')
 
 function onInitializeStateCore(state) {
-  state.md[disabledMarpitSymbol] = false
+  state.md[MarpitSymbol] = true
 
-  state.disableMarpit = function disableMarpit(value = true) {
-    state.md[disabledMarpitSymbol] = value
+  state.marpit = function marpit(value) {
+    state.md[MarpitSymbol] = value
   }
 }
 
 function ruleWrapper(basePlugin) {
   return function wrappedRule(state, ...args) {
-    if (state.md[disabledMarpitSymbol]) return false
+    if (!state.md[MarpitSymbol]) return false
 
     return basePlugin(state, ...args)
   }
@@ -30,8 +29,8 @@ function ruleWrapper(basePlugin) {
  *     within the callback will check the disabled state of Marpit.
  */
 function useMarpitPlugin(md, callback) {
-  if (!md[usingMarpit]) {
-    md[usingMarpit] = true
+  if (!Object.prototype.hasOwnProperty.call(md, MarpitSymbol)) {
+    md[MarpitSymbol] = true
 
     const { State } = md.core
 

--- a/src/helpers/plugin.js
+++ b/src/helpers/plugin.js
@@ -1,6 +1,4 @@
-/**
- * @module
- */
+/** @module */
 
 export const MarpitSymbol = Symbol('Marpit')
 
@@ -26,7 +24,8 @@ function ruleWrapper(basePlugin) {
  * @alias module:helpers/plugin
  * @param {MarkdownIt} md markdown-it instance.
  * @param {Function} callback Callback function. markdown-it rules extended
- *     within the callback will check the disabled state of Marpit.
+ *     within the callback will check the state of Marpit features toggled by
+ *     `StateCore#marpit`.
  */
 function useMarpitPlugin(md, callback) {
   if (!Object.prototype.hasOwnProperty.call(md, MarpitSymbol)) {

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -18,8 +18,11 @@ import parse from './background_image/parse'
  *
  * @alias module:markdown/background_image
  * @param {MarkdownIt} md markdown-it instance.
+ * @param {Marpit} marpit Marpit instance.
  */
-function backgroundImage(md) {
+function backgroundImage(md, marpit) {
+  if (!marpit.options.backgroundSyntax) return
+
   parse(md)
   apply(md)
   advanced(md)

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -42,22 +42,6 @@ const useMarpitRuler = (md, process) => {
   const wrappedRule = fn => (state, ...args) =>
     shouldUseMarpit(state.env) && fn(state, ...args)
 
-  ruler.after = function marpitAfter(afterName, ruleName, fn, options) {
-    return after.call(this, afterName, ruleName, wrappedRule(fn), options)
-  }
-
-  ruler.at = function marpitAt(name, fn, options) {
-    return at.call(this, name, wrappedRule(fn), options)
-  }
-
-  ruler.before = function marpitBefore(beforeName, ruleName, fn, options) {
-    return before.call(this, beforeName, ruleName, wrappedRule(fn), options)
-  }
-
-  ruler.push = function marpitPush(ruleName, fn, options) {
-    return push.call(this, ruleName, wrappedRule(fn), options)
-  }
-
   const reset = () => {
     ruler.after = after
     ruler.at = at
@@ -66,6 +50,22 @@ const useMarpitRuler = (md, process) => {
   }
 
   try {
+    ruler.after = function marpitAfter(afterName, ruleName, fn, options) {
+      return after.call(this, afterName, ruleName, wrappedRule(fn), options)
+    }
+
+    ruler.at = function marpitAt(name, fn, options) {
+      return at.call(this, name, wrappedRule(fn), options)
+    }
+
+    ruler.before = function marpitBefore(beforeName, ruleName, fn, options) {
+      return before.call(this, beforeName, ruleName, wrappedRule(fn), options)
+    }
+
+    ruler.push = function marpitPush(ruleName, fn, options) {
+      return push.call(this, ruleName, wrappedRule(fn), options)
+    }
+
     process()
   } catch (e) {
     reset()
@@ -277,6 +277,9 @@ class Marpit {
 
   /**
    * Load the specified markdown-it plugin with given parameters.
+   *
+   * Please notice the extended rule may disable by `marpit` env. Consider to
+   * use `marpit.markdown.use()` if any problem was occurred.
    *
    * @param {Function} plugin markdown-it plugin.
    * @param {...*} params Params to pass into plugin.

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -1,5 +1,5 @@
 import MarkdownIt from 'markdown-it'
-import useMarpitPlugin, { disabledMarpitSymbol } from './helpers/plugin'
+import useMarpitPlugin, { MarpitSymbol } from './helpers/plugin'
 import wrapArray from './helpers/wrap_array'
 import ThemeSet from './theme_set'
 import { marpitContainer } from './element'
@@ -173,9 +173,7 @@ class Marpit {
    */
   render(markdown, env = {}) {
     const html = this.renderMarkdown(markdown, env)
-
-    if (this.markdown[disabledMarpitSymbol])
-      return { html, css: '', comments: [] }
+    if (!this.markdown[MarpitSymbol]) return { html, css: '', comments: [] }
 
     return {
       html,
@@ -200,7 +198,7 @@ class Marpit {
   renderMarkdown(markdown, env = {}) {
     const tokens = this.markdown.parse(markdown, env)
 
-    if (env.htmlAsArray && !this.markdown[disabledMarpitSymbol]) {
+    if (env.htmlAsArray && this.markdown[MarpitSymbol]) {
       return this.lastSlideTokens.map(slideTokens =>
         this.markdown.renderer.render(slideTokens, this.markdown.options, env)
       )

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -15,18 +15,21 @@ describe('Marpit background image plugin', () => {
     customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
     themeSet: { getThemeProp: () => 100 },
-    options: { inlineSVG: svg },
+    options: { backgroundSyntax: true, inlineSVG: svg },
   })
 
-  const md = (svg = false, filters = false) =>
-    new MarkdownIt()
+  const md = (svg = false, filters = false) => {
+    const stub = marpitStub(svg)
+
+    return new MarkdownIt()
       .use(comment)
       .use(slide)
-      .use(parseDirectives, marpitStub(svg))
-      .use(applyDirectives, marpitStub(svg))
-      .use(inlineSVG, marpitStub(svg))
+      .use(parseDirectives, stub)
+      .use(applyDirectives, stub)
+      .use(inlineSVG, stub)
       .use(parseImage, { filters })
-      .use(backgroundImage)
+      .use(backgroundImage, stub)
+  }
 
   const bgDirective = (url, mdInstance) => {
     const [first, second] = mdInstance.parse(`![bg](${url})\n\n---`)

--- a/test/markdown/sweep.js
+++ b/test/markdown/sweep.js
@@ -20,7 +20,7 @@ describe('Marpit sweep plugin', () => {
     const marpitStub = {
       customDirectives: { global: {}, local: {} },
       themeSet: new Map(),
-      options: { inlineSVG: false },
+      options: { backgroundSyntax: true, inlineSVG: false },
     }
 
     const markdown = md({ breaks: true })
@@ -29,7 +29,7 @@ describe('Marpit sweep plugin', () => {
       .use(applyDirectives, marpitStub)
       .use(inlineSVG, marpitStub)
       .use(parseImage)
-      .use(backgroundImage)
+      .use(backgroundImage, marpitStub)
 
     const $ = cheerio.load(
       markdown.render(dedent`

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -376,18 +376,18 @@ describe('Marpit', () => {
     })
 
     describe('Enhancement of markdown-it plugin system', () => {
-      describe('StateCore#disableMarpit', () => {
-        const disableMarpitPlugin = md =>
-          md.core.ruler.before('normalize', 'disable_marpit', state => {
-            if (state.env.marpit === false) state.disableMarpit()
-          })
+      describe('StateCore#marpit', () => {
+        const controlMarpitPlugin = md =>
+          md.core.ruler.before('normalize', 'disable_marpit', state =>
+            state.marpit(state.env.marpit)
+          )
 
-        it('disables Marpit core rules', () => {
+        it('toggles enable or disable Marpit core rules', () => {
           const marpitRule = jest.fn()
           const mdRule = jest.fn()
 
           const marpit = new Marpit()
-            .use(disableMarpitPlugin)
+            .use(controlMarpitPlugin)
             .use(md => md.core.ruler.after('normalize', 'test', marpitRule))
 
           marpit.markdown.use(md =>
@@ -411,10 +411,10 @@ describe('Marpit', () => {
           expect(retEnabled.comments).toStrictEqual([[]])
         })
 
-        it('allows disabling also in the instance of markdown-it', () => {
+        it('allows control also in the instance of markdown-it', () => {
           const md = new MarkdownIt()
             .use(new Marpit().markdownItPlugins)
-            .use(disableMarpitPlugin)
+            .use(controlMarpitPlugin)
 
           expect(md.render('', { marpit: false })).not.toContain('section')
           expect(md.render('', { marpit: true })).toContain('section')

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -148,6 +148,18 @@ describe('Marpit', () => {
           expect(cheerio.load(html[1])('section#2 > h2')).toHaveLength(1)
         })
       })
+
+      context('when passed marpit prop as false', () => {
+        it('disables extended rules by Marpit', () => {
+          const markdown = '# Page1\n***\n## Page2'
+          const { html } = new Marpit().render(markdown, { marpit: false })
+          const $ = cheerio.load(html)
+
+          expect(html).toBe(new MarkdownIt('commonmark').render(markdown))
+          expect($('section')).toHaveLength(0)
+          expect($('hr')).toHaveLength(1)
+        })
+      })
     })
 
     context('with inlineSVG option', () => {


### PR DESCRIPTION
We enhanced markdown-it plugin system to be able to toggle Marpit features by the plugin. [markdown-it's `StateCore`](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/state_core.js) has `marpit()`, and you can turn off Marpit core rules by calling `marpit(false)` before `normalize` rule.

```javascript
marpit.use(md => md.core.ruler.before('normalize', 'disable', state => state.marpit(false)))
```

### Motivation

Marpit has an interface of markdown-it plugin and can extend a plain markdown-it by [`marpit.markdownItPlugins`](https://marpit-api.marp.app/marpit#markdownItPlugins). We are planning to create Marp VSCode plugin by making use of this ability. (yhatt/marp#118)

Currently, Marpit cannot disable by injected markdown-it instance. But this implementation would get a skill to control Marpit features.