### PR TITLE
Fix type definition of custom directive parser to allow array and object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix type definition of custom directive parser to allow array and object ([#130](https://github.com/marp-team/marpit/pull/130))
+
 ## v0.7.0 - 2019-01-30
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module '@marp-team/marpit' {
 
   type MarpitDirectiveDefinitions = {
     [directive: string]: (
-      value: string,
+      value: string | object | (string | object)[],
       marpit?: Marpit
     ) => { [meta: string]: any }
   }


### PR DESCRIPTION
The type definition of directive parser defined at `customDirectives` should allow not only string but also object and array.

```markdown
---
customArray:
  - test
  - array
customObject:
  a: b
  c: d
---
```