### PR TITLE
Use re-exported markdown-it Token from state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Use re-exported markdown-it Token from state ([#132](https://github.com/marp-team/marpit/pull/132))
+
 ## v0.7.1 - 2019-02-04
 
 ### Fixed

--- a/src/helpers/wrap_tokens.js
+++ b/src/helpers/wrap_tokens.js
@@ -1,10 +1,10 @@
 /** @module */
-import Token from 'markdown-it/lib/token'
 
 /**
  * Wrap array of tokens by specified container object.
  *
  * @alias module:helpers/wrap_tokens
+ * @param {Token} Token markdown-it's Token class.
  * @param {String} type Token type. It will be suffixed by `_open` / `_close`.
  * @param {Object} container A container object to wrap tokens, includes tag
  *     name and attributes.
@@ -14,7 +14,7 @@ import Token from 'markdown-it/lib/token'
  * @param {Token[]} [tokens=[]] Wrapping tokens.
  * @returns {Token[]} Wrapped tokens.
  */
-function wrapTokens(type, container, tokens = []) {
+function wrapTokens(Token, type, container, tokens = []) {
   const { tag } = container
 
   // Update nesting level of wrapping tokens

--- a/src/markdown/background_image/advanced.js
+++ b/src/markdown/background_image/advanced.js
@@ -43,9 +43,11 @@ function advancedBackground(md) {
           // Add the isolated layer for background image
           newTokens.push(
             ...wrapTokens(
+              state.Token,
               'marpit_advanced_background_foreign_object',
               { tag: 'foreignObject', width, height },
               wrapTokens(
+                state.Token,
                 'marpit_advanced_background_section',
                 {
                   ...open.attrs.reduce((o, [k, v]) => ({ ...o, [k]: v }), {}),
@@ -54,6 +56,7 @@ function advancedBackground(md) {
                   'data-marpit-advanced-background': 'background',
                 },
                 wrapTokens(
+                  state.Token,
                   'marpit_advanced_background_image_container',
                   {
                     tag: 'div',
@@ -75,10 +78,14 @@ function advancedBackground(md) {
                       if (img.filter) style.set('filter', img.filter)
 
                       imageTokens.push(
-                        ...wrapTokens('marpit_advanced_background_image', {
-                          tag: 'figure',
-                          style: style.toString(),
-                        })
+                        ...wrapTokens(
+                          state.Token,
+                          'marpit_advanced_background_image',
+                          {
+                            tag: 'figure',
+                            style: style.toString(),
+                          }
+                        )
                       )
                     }
 
@@ -106,6 +113,7 @@ function advancedBackground(md) {
           newTokens.push(
             t,
             ...wrapTokens(
+              state.Token,
               'marpit_advanced_background_foreign_object',
               {
                 tag: 'foreignObject',
@@ -113,7 +121,7 @@ function advancedBackground(md) {
                 height,
                 'data-marpit-advanced-background': 'pseudo',
               },
-              wrapTokens('marpit_advanced_pseudo_section', {
+              wrapTokens(state.Token, 'marpit_advanced_pseudo_section', {
                 tag: 'section',
                 class: open.attrGet('class'),
                 style: style.toString(),

--- a/src/markdown/container.js
+++ b/src/markdown/container.js
@@ -17,7 +17,12 @@ function container(md, containers) {
     if (state.inlineMode) return
 
     for (const cont of target)
-      state.tokens = wrapTokens('marpit_containers', cont, state.tokens)
+      state.tokens = wrapTokens(
+        state.Token,
+        'marpit_containers',
+        cont,
+        state.tokens
+      )
   })
 }
 

--- a/src/markdown/header_and_footer.js
+++ b/src/markdown/header_and_footer.js
@@ -32,6 +32,7 @@ function headerAndFooter(md) {
 
       const createMarginalTokens = (tag, markdown) =>
         wrapTokens(
+          state.Token,
           `marpit_${tag}`,
           { tag, close: { block: true } },
           getParsed(markdown)

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -1,5 +1,4 @@
 /** @module */
-import Token from 'markdown-it/lib/token'
 import split from '../helpers/split'
 
 /**
@@ -40,7 +39,7 @@ function headingDivider(md, marpit) {
       const [token] = slideTokens
 
       if (token && splitFunc(token) && newTokens.some(t => !t.hidden)) {
-        const hr = new Token('hr', '', 0)
+        const hr = new state.Token('hr', '', 0)
         hr.hidden = true
 
         newTokens.push(hr)

--- a/src/markdown/inline_svg.js
+++ b/src/markdown/inline_svg.js
@@ -30,6 +30,7 @@ function inlineSVG(md, marpit) {
 
         newTokens.push(
           ...wrapTokens(
+            state.Token,
             'marpit_inline_svg',
             {
               tag: 'svg',
@@ -39,6 +40,7 @@ function inlineSVG(md, marpit) {
               close: { meta: { marpitSlideElement: -1 } },
             },
             wrapTokens(
+              state.Token,
               'marpit_inline_svg_content',
               { tag: 'foreignObject', width: w, height: h },
               tokens

--- a/src/markdown/slide.js
+++ b/src/markdown/slide.js
@@ -42,6 +42,7 @@ function slide(md, opts = {}) {
         return [
           ...arr,
           ...wrapTokens(
+            state.Token,
             'marpit_slide',
             {
               ...(opts.attributes || {}),

--- a/src/markdown/slide_container.js
+++ b/src/markdown/slide_container.js
@@ -28,7 +28,7 @@ function slideContainer(md, containers) {
         newTokens.push(
           ...target.reduce(
             (slides, conts) =>
-              wrapTokens('marpit_slide_containers', conts, slides),
+              wrapTokens(state.Token, 'marpit_slide_containers', conts, slides),
             tokens
           )
         )


### PR DESCRIPTION
To manipulate rendered tokens, we used markdown-it token from markdown-it/lib/token directly. But this way is not suitable for the policy of markdown-it plugins. When extends existed instance via `applyMarkdownItPlugins`, markdown-it version might not match between two Token classes.

We will fix to use the re-exported `Token` class by `StateCore`. Marpit can use the correct `Token` corresponded to the instance.

https://github.com/markdown-it/markdown-it/blob/bda94b0521f206a02427ec58cb9a848d9c993ccb/lib/rules_core/state_core.js#L16-L17