### PR TITLE
Fix broken emoji on docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Use re-exported markdown-it Token from state ([#132](https://github.com/marp-team/marpit/pull/132))
+- Fix broken emoji on docs ([#134](https://github.com/marp-team/marpit/pull/134))
 
 ### Changed
 

--- a/docs/image-syntax.md
+++ b/docs/image-syntax.md
@@ -2,15 +2,15 @@
 
 Marpit has extended Markdown image syntax `![](image.jpg)` to be helpful creating beautiful slides.
 
-|              Features              |       Inline image       |         Slide BG         |    Advanced BG     |
-| :--------------------------------: | :----------------------: | :----------------------: | :----------------: |
-|  [Resizing by keywords][resizing]  |       `auto` only        |    :heavy_check_mark:    | :heavy_check_mark: |
-| [Resizing by percentage][resizing] | :heavy_multiplication_x: |    :heavy_check_mark:    | :heavy_check_mark: |
-|   [Resizing by length][resizing]   |    :heavy_check_mark:    |    :heavy_check_mark:    | :heavy_check_mark: |
-|      [Image filters][filters]      |    :heavy_check_mark:    | :heavy_multiplication_x: | :heavy_check_mark: |
-|    [Background color][bgcolor]     |            -             |    :heavy_check_mark:    | :heavy_check_mark: |
-|  [Multiple backgrounds][multiple]  |            -             | :heavy_multiplication_x: | :heavy_check_mark: |
-|     [Split backgrounds][split]     |            -             | :heavy_multiplication_x: | :heavy_check_mark: |
+|              Features              | Inline image | Slide BG | Advanced BG |
+| :--------------------------------: | :----------: | :------: | :---------: |
+|  [Resizing by keywords][resizing]  | `auto` only  |    ✅    |     ✅      |
+| [Resizing by percentage][resizing] |      ❌      |    ✅    |     ✅      |
+|   [Resizing by length][resizing]   |      ✅      |    ✅    |     ✅      |
+|      [Image filters][filters]      |      ✅      |    ❌    |     ✅      |
+|    [Background color][bgcolor]     |      -       |    ✅    |     ✅      |
+|  [Multiple backgrounds][multiple]  |      -       |    ❌    |     ✅      |
+|     [Split backgrounds][split]     |      -       |    ❌    |     ✅      |
 
 [resizing]: #resizing-image
 [filters]: #image-filters
@@ -123,7 +123,7 @@ It is same as defining [`<!-- _backgroundColor: "#fff" -->` spot directive](/dir
 
 ## Advanced backgrounds
 
-!> :triangular_ruler: It will work only in experimental [inline SVG slide](/inline-svg).
+!> 📐 It will work only in experimental [inline SVG slide](/inline-svg).
 
 The advanced backgrounds support [multiple backgrounds][multiple], [split backgrounds][split], and [image filters for background][filters].
 

--- a/docs/inline-svg.md
+++ b/docs/inline-svg.md
@@ -1,6 +1,6 @@
 # Inline SVG slide _(experimental)_
 
-!> :triangular_ruler: This feature is experimental because of a strange rendering in some browsers.
+!> 📐 This feature is experimental because of a strange rendering in some browsers.
 
 When you set [`inlineSVG: true` in Marpit constructor option](/usage#triangular_ruler-inline-svg-slide), each `<section>` elements are wrapped with inline SVG.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -18,15 +18,15 @@ In fact, this framework is created for using as the base of [a core converter][m
 
 ## Features
 
-### [:pencil: Marpit Markdown](/markdown) {docsify-ignore}
+### [📝 Marpit Markdown](/markdown) {docsify-ignore}
 
 We have extended several features into [markdown-it](https://github.com/markdown-it/markdown-it) parser to support writing awesome slides, such as [_Directives_](/directives) and [_Slide backgrounds_](/image-syntax#slide-backgrounds). Additional syntaxes place importance on a compatibility with general Markdown documents.
 
-### [:art: Theme CSS by clean markup](/theme-css) {docsify-ignore}
+### [🎨 Theme CSS by clean markup](/theme-css) {docsify-ignore}
 
 Marpit has the CSS theming system that can design slides everything. Unlike other slide frameworks, there are not any predefined classes and mixins. You have only to focus styling HTML elements by pure CSS. Marpit would take care of the selected theme's necessary conversion.
 
-### [:triangular_ruler: Inline SVG slide <i>(Experimental)</i>](/inline-svg) {docsify-ignore}
+### [📐 Inline SVG slide <i>(Experimental)</i>](/inline-svg) {docsify-ignore}
 
 Optionally `<svg>` element can use as the container of each slide page. It can be realized the pixel-perfect scaling of the slide only by CSS, so handling slides in integrated apps become simplified. The isolated layer made by `<foreignObject>` can provide [_advanced backgrounds_](/image-syntax#advanced-backgrounds) for the slide with keeping the original Markdown DOM structure.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,7 +19,7 @@ By passing object of options, you can customize the behavior of Marpit instance 
 
 _**[See all options at JSDoc](https://marpit-api.marp.app/marpit)** to details._ Here we will introduce useful recipes.
 
-#### :pencil: [markdown-it](https://github.com/markdown-it/markdown-it) parser setting
+#### 📝 [markdown-it](https://github.com/markdown-it/markdown-it) parser setting
 
 You can customize the behavior of Markdown parser by `markdown` option. It will pass to [markdown-it initializer](https://github.com/markdown-it/markdown-it#init-with-presets-and-options) as it is.
 
@@ -32,7 +32,7 @@ const marpit = new Marpit({
 })
 ```
 
-#### :package: Customize container elements
+#### 📦 Customize container elements
 
 You can customize container HTML elements too. These settings are using to scope the converted CSS. [`Element` class](https://marpit-api.marp.app/element) helps to specify container(s).
 
@@ -63,7 +63,7 @@ It would render elements like this:
 
 The default container is [`<div class="marpit">`](https://marpit-api.marp.app/module-element.html#.marpitContainer), and no slide containers (render only `<section>`). If you may not use any containers and CSS scoping, please set `container` option as `false`.
 
-#### :triangular_ruler: Inline SVG slide
+#### 📐 Inline SVG slide
 
 Turn on the _(experimental)_ [inline SVG slide](/inline-svg).
 


### PR DESCRIPTION
Docsify is using emoji via GitHub CDN but it seems no longer providing the emoji image. Therefore, we have to replace Emoji shortcode syntax to Unicode emoji on docs.

|Previous|After|
|:---:|:---:|
|<img width="886" alt="2019-02-13 13 55 05" src="https://user-images.githubusercontent.com/3993388/52687889-2e9b2f00-2f97-11e9-8f29-94ce3cdc5935.png">|<img width="880" alt="2019-02-13 13 55 54" src="https://user-images.githubusercontent.com/3993388/52687896-322eb600-2f97-11e9-8d78-deff5e37c665.png">|

