### PR TITLE
Simplify Marpit plugins by using injected instance into markdown-it instance

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,8 @@ extends:
   - airbnb-base
   - prettier
 
+parser: babel-eslint
+
 rules:
   max-len:
     - error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Upgrade dependent packages to the latest version ([#143](https://github.com/marp-team/marpit/pull/143))
+- Simplify Marpit plugins by using injected instance into markdown-it instance ([#147](https://github.com/marp-team/marpit/pull/147))
 
 ### Deprecated
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,7 @@ module.exports = {
   presets: [['@babel/preset-env', { targets: { node: '6.14' } }]],
   plugins: [
     ['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-private-methods',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -58,10 +58,13 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.4.0",
+    "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
+    "@babel/plugin-proposal-private-methods": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
     "autoprefixer": "^9.5.0",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^24.5.0",
     "cheerio": "^1.0.0-rc.2",
     "codecov": "^3.2.0",

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -19,9 +19,10 @@ import parse from './background_image/parse'
  *
  * @alias module:markdown/background_image
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  */
-function backgroundImage(md, marpit) {
+function backgroundImage(md) {
+  const { marpit } = md
+
   if (!marpit.options.backgroundSyntax) return
 
   parse(md)

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import advanced from './background_image/advanced'
 import apply from './background_image/apply'
 import parse from './background_image/parse'
@@ -28,4 +29,4 @@ function backgroundImage(md, marpit) {
   advanced(md)
 }
 
-export default backgroundImage
+export default marpitPlugin(backgroundImage)

--- a/src/markdown/background_image/advanced.js
+++ b/src/markdown/background_image/advanced.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from '../marpit_plugin'
 import InlineStyle from '../../helpers/inline_style'
 import wrapTokens from '../../helpers/wrap_tokens'
 
@@ -148,4 +149,4 @@ function advancedBackground(md) {
   )
 }
 
-export default advancedBackground
+export default marpitPlugin(advancedBackground)

--- a/src/markdown/background_image/apply.js
+++ b/src/markdown/background_image/apply.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from '../marpit_plugin'
 
 /**
  * Marpit background image apply plugin.
@@ -111,4 +112,4 @@ function backgroundImageApply(md) {
   )
 }
 
-export default backgroundImageApply
+export default marpitPlugin(backgroundImageApply)

--- a/src/markdown/background_image/parse.js
+++ b/src/markdown/background_image/parse.js
@@ -1,5 +1,6 @@
 /** @module */
 import colorString from 'color-string'
+import marpitPlugin from '../marpit_plugin'
 
 const bgSizeKeywords = {
   auto: 'auto',
@@ -59,4 +60,4 @@ function backgroundImageParse(md) {
   )
 }
 
-export default backgroundImageParse
+export default marpitPlugin(backgroundImageParse)

--- a/src/markdown/collect.js
+++ b/src/markdown/collect.js
@@ -11,9 +11,10 @@ import marpitPlugin from './marpit_plugin'
  *
  * @alias module:markdown/collect
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  */
-function collect(md, marpit) {
+function collect(md) {
+  const { marpit } = md
+
   md.core.ruler.push('marpit_collect', state => {
     if (state.inlineMode) return
 

--- a/src/markdown/collect.js
+++ b/src/markdown/collect.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 
 /**
  * Marpit collect plugin.
@@ -59,4 +60,4 @@ function collect(md, marpit) {
   })
 }
 
-export default collect
+export default marpitPlugin(collect)

--- a/src/markdown/comment.js
+++ b/src/markdown/comment.js
@@ -14,12 +14,10 @@ const commentMatcherClosing = /-->/
  *
  * @alias module:markdown/comment
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Object} [opts]
- * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
  */
-function comment(md, opts = {}) {
+function comment(md) {
   const parse = (token, content) => {
-    const parsed = yaml(content, !!opts.looseYAML)
+    const parsed = yaml(content, !!md.marpit.options.looseYAML)
 
     token.meta = {
       ...(token.meta || {}),

--- a/src/markdown/comment.js
+++ b/src/markdown/comment.js
@@ -1,5 +1,6 @@
 /** @module */
 import yaml from './directives/yaml'
+import marpitPlugin from './marpit_plugin'
 
 const commentMatcher = /<!--+\s*([\s\S]*?)\s*--+>/
 const commentMatcherOpening = /^<!--/
@@ -105,4 +106,4 @@ function comment(md, opts = {}) {
   )
 }
 
-export default comment
+export default marpitPlugin(comment)

--- a/src/markdown/container.js
+++ b/src/markdown/container.js
@@ -1,5 +1,6 @@
 /** @module */
 import marpitPlugin from './marpit_plugin'
+import wrapArray from '../helpers/wrap_array'
 import wrapTokens from '../helpers/wrap_tokens'
 
 /**
@@ -7,9 +8,9 @@ import wrapTokens from '../helpers/wrap_tokens'
  *
  * @alias module:markdown/container
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Element[]} containers Array of container elements.
  */
-function container(md, containers) {
+function container(md) {
+  const containers = wrapArray(md.marpit.options.container)
   if (!containers) return
 
   const target = [...containers].reverse()

--- a/src/markdown/container.js
+++ b/src/markdown/container.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import wrapTokens from '../helpers/wrap_tokens'
 
 /**
@@ -26,4 +27,4 @@ function container(md, containers) {
   })
 }
 
-export default container
+export default marpitPlugin(container)

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -9,14 +9,15 @@ import InlineStyle from '../../helpers/inline_style'
  *
  * @alias module:markdown/directives/apply
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  * @param {Object} [opts]
  * @param {boolean} [opts.dataset=true] Assigns directives as HTML data
  *     attributes of each section tag.
  * @param {boolean} [opts.css=true] Assigns directives as CSS Custom Properties
  *     of each section tag.
  */
-function apply(md, marpit, opts = {}) {
+function apply(md, opts = {}) {
+  const { marpit } = md
+
   const dataset = opts.dataset === undefined ? true : !!opts.dataset
   const css = opts.css === undefined ? true : !!opts.css
 

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -1,6 +1,7 @@
 /** @module */
 import kebabCase from 'lodash.kebabcase'
 import builtInDirectives from './directives'
+import marpitPlugin from '../marpit_plugin'
 import InlineStyle from '../../helpers/inline_style'
 
 /**
@@ -98,4 +99,4 @@ function apply(md, marpit, opts = {}) {
   )
 }
 
-export default apply
+export default marpitPlugin(apply)

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -12,14 +12,15 @@ import marpitPlugin from '../marpit_plugin'
  *
  * @alias module:markdown/directives/parse
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  * @param {Object} [opts]
  * @param {boolean} [opts.frontMatter=true] Switch feature to support YAML
  *     front-matter. If true, you can use Jekyll style directive setting to the
  *     first page.
  * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
  */
-function parse(md, marpit, opts = {}) {
+function parse(md, opts = {}) {
+  const { marpit } = md
+
   // Front-matter support
   const frontMatter = opts.frontMatter === undefined ? true : !!opts.frontMatter
   let frontMatterObject = {}

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -16,7 +16,6 @@ import marpitPlugin from '../marpit_plugin'
  * @param {boolean} [opts.frontMatter=true] Switch feature to support YAML
  *     front-matter. If true, you can use Jekyll style directive setting to the
  *     first page.
- * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
  */
 function parse(md, opts = {}) {
   const { marpit } = md
@@ -33,7 +32,7 @@ function parse(md, opts = {}) {
     md.use(MarkdownItFrontMatter, fm => {
       frontMatterObject.text = fm
 
-      const parsed = yaml(fm, !!opts.looseYAML)
+      const parsed = yaml(fm, !!md.marpit.options.looseYAML)
       if (parsed !== false) frontMatterObject.yaml = parsed
     })
   }

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -2,6 +2,7 @@
 import MarkdownItFrontMatter from 'markdown-it-front-matter'
 import yaml from './yaml'
 import * as directives from './directives'
+import marpitPlugin from '../marpit_plugin'
 
 /**
  * Parse Marpit directives and store result to the slide token meta.
@@ -198,4 +199,4 @@ function parse(md, marpit, opts = {}) {
   })
 }
 
-export default parse
+export default marpitPlugin(parse)

--- a/src/markdown/header_and_footer.js
+++ b/src/markdown/header_and_footer.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import wrapTokens from '../helpers/wrap_tokens'
 
 /**
@@ -67,4 +68,4 @@ function headerAndFooter(md) {
   )
 }
 
-export default headerAndFooter
+export default marpitPlugin(headerAndFooter)

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -10,9 +10,10 @@ import split from '../helpers/split'
  *
  * @alias module:markdown/heading_divider
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  */
-function headingDivider(md, marpit) {
+function headingDivider(md) {
+  const { marpit } = md
+
   md.core.ruler.before('marpit_slide', 'marpit_heading_divider', state => {
     let target = marpit.options.headingDivider
 

--- a/src/markdown/heading_divider.js
+++ b/src/markdown/heading_divider.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import split from '../helpers/split'
 
 /**
@@ -52,4 +53,4 @@ function headingDivider(md, marpit) {
   })
 }
 
-export default headingDivider
+export default marpitPlugin(headingDivider)

--- a/src/markdown/inline_svg.js
+++ b/src/markdown/inline_svg.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import split from '../helpers/split'
 import wrapTokens from '../helpers/wrap_tokens'
 
@@ -54,4 +55,4 @@ function inlineSVG(md, marpit) {
   })
 }
 
-export default inlineSVG
+export default marpitPlugin(inlineSVG)

--- a/src/markdown/inline_svg.js
+++ b/src/markdown/inline_svg.js
@@ -8,9 +8,10 @@ import wrapTokens from '../helpers/wrap_tokens'
  *
  * @alias module:markdown/inline_svg
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  */
-function inlineSVG(md, marpit) {
+function inlineSVG(md) {
+  const { marpit } = md
+
   md.core.ruler.after('marpit_directives_parse', 'marpit_inline_svg', state => {
     if (!marpit.options.inlineSVG || state.inlineMode) return
 

--- a/src/markdown/marpit_plugin.js
+++ b/src/markdown/marpit_plugin.js
@@ -1,0 +1,21 @@
+/** @module */
+import Marpit from '../marpit'
+
+/**
+ * Marpit plugin wrapper.
+ *
+ * Convert passed markdown-it plugin to Marpit plugin. Marpit plugin would
+ * require that markdown-it instance has `marpit` member as Marpit instance.
+ *
+ * @alias module:markdown/marpit_plugin
+ * @returns {Function} markdown-it plugin for Marpit.
+ */
+export default function marpitPlugin(plugin) {
+  return (md, ...args) => {
+    if (md.marpit instanceof Marpit) return plugin.call(this, md, ...args)
+
+    throw new Error(
+      "Marpit's markdown-it plugin requires `marpit` member as Marpit instance."
+    )
+  }
+}

--- a/src/markdown/marpit_plugin.js
+++ b/src/markdown/marpit_plugin.js
@@ -1,5 +1,4 @@
 /** @module */
-import Marpit from '../marpit'
 
 /**
  * Marpit plugin wrapper.
@@ -10,10 +9,12 @@ import Marpit from '../marpit'
  * @alias module:markdown/marpit_plugin
  * @returns {Function} markdown-it plugin for Marpit.
  */
-export default function marpitPlugin(plugin) {
+function marpitPlugin(plugin) {
   return (md, ...args) => {
     if (md.marpit) return plugin.call(this, md, ...args)
 
     throw new Error("Marpit's markdown-it plugin requires `marpit` member.")
   }
 }
+
+export default marpitPlugin

--- a/src/markdown/marpit_plugin.js
+++ b/src/markdown/marpit_plugin.js
@@ -7,6 +7,7 @@
  * require that markdown-it instance has `marpit` member.
  *
  * @alias module:markdown/marpit_plugin
+ * @param {Function} plugin Base plugin for markdown-it.
  * @returns {Function} markdown-it plugin for Marpit.
  */
 function marpitPlugin(plugin) {

--- a/src/markdown/marpit_plugin.js
+++ b/src/markdown/marpit_plugin.js
@@ -5,17 +5,15 @@ import Marpit from '../marpit'
  * Marpit plugin wrapper.
  *
  * Convert passed markdown-it plugin to Marpit plugin. Marpit plugin would
- * require that markdown-it instance has `marpit` member as Marpit instance.
+ * require that markdown-it instance has `marpit` member.
  *
  * @alias module:markdown/marpit_plugin
  * @returns {Function} markdown-it plugin for Marpit.
  */
 export default function marpitPlugin(plugin) {
   return (md, ...args) => {
-    if (md.marpit instanceof Marpit) return plugin.call(this, md, ...args)
+    if (md.marpit) return plugin.call(this, md, ...args)
 
-    throw new Error(
-      "Marpit's markdown-it plugin requires `marpit` member as Marpit instance."
-    )
+    throw new Error("Marpit's markdown-it plugin requires `marpit` member.")
   }
 }

--- a/src/markdown/parse_image.js
+++ b/src/markdown/parse_image.js
@@ -17,11 +17,11 @@ const escape = target =>
  *
  * @alias module:markdown/parse_image
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Object} [opts]
- * @param {boolean} [opts.filters=true] Switch feature to support CSS filters.
  */
-function parseImage(md, opts = {}) {
-  const pluginOptions = { filters: true, ...opts }
+function parseImage(md) {
+  const isEnabledFilters =
+    md.marpit.options.filters !== undefined ? md.marpit.options.filters : true
+
   const optionMatchers = new Map()
 
   // The scale percentage for resize background
@@ -38,7 +38,7 @@ function parseImage(md, opts = {}) {
     matches => ({ height: matches[1] })
   )
 
-  if (pluginOptions.filters) {
+  if (isEnabledFilters) {
     // CSS filters
     optionMatchers.set(/^blur(?::(.+))?$/, (matches, meta) => ({
       filters: [...meta.filters, ['blur', escape(matches[1] || '10px')]],

--- a/src/markdown/parse_image.js
+++ b/src/markdown/parse_image.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import InlineStyle from '../helpers/inline_style'
 
 const escape = target =>
@@ -153,4 +154,4 @@ function parseImage(md, opts = {}) {
   })
 }
 
-export default parseImage
+export default marpitPlugin(parseImage)

--- a/src/markdown/slide.js
+++ b/src/markdown/slide.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import split from '../helpers/split'
 import wrapTokens from '../helpers/wrap_tokens'
 
@@ -67,4 +68,4 @@ function slide(md, opts = {}) {
   })
 }
 
-export default slide
+export default marpitPlugin(slide)

--- a/src/markdown/slide_container.js
+++ b/src/markdown/slide_container.js
@@ -1,6 +1,7 @@
 /** @module */
 import marpitPlugin from './marpit_plugin'
 import split from '../helpers/split'
+import wrapArray from '../helpers/wrap_array'
 import wrapTokens from '../helpers/wrap_tokens'
 
 /**
@@ -8,9 +9,9 @@ import wrapTokens from '../helpers/wrap_tokens'
  *
  * @alias module:markdown/slide_container
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Element[]} containers Array of container elements.
  */
-function slideContainer(md, containers) {
+function slideContainer(md) {
+  const containers = wrapArray(md.marpit.options.slideContainer)
   if (!containers) return
 
   const target = [...containers].reverse()

--- a/src/markdown/slide_container.js
+++ b/src/markdown/slide_container.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 import split from '../helpers/split'
 import wrapTokens from '../helpers/wrap_tokens'
 
@@ -38,4 +39,4 @@ function slideContainer(md, containers) {
   })
 }
 
-export default slideContainer
+export default marpitPlugin(slideContainer)

--- a/src/markdown/style/assign.js
+++ b/src/markdown/style/assign.js
@@ -38,14 +38,11 @@ const injectScopePostCSSplugin = postcss.plugin(
  *
  * @alias module:markdown/style/assign
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Object} [opts]
- * @param {boolean} [opts.supportScoped=true] Setting whether support scoped
- *     style.
  */
-function assign(md, opts = {}) {
+function assign(md) {
   const { marpit } = md
   const shouldSupportScoped =
-    'supportScoped' in opts ? !!opts.supportScoped : true
+    marpit.options.scopedStyle !== undefined ? marpit.options.scopedStyle : true
 
   md.core.ruler.after('marpit_slide', 'marpit_style_assign', state => {
     if (state.inlineMode) return

--- a/src/markdown/style/assign.js
+++ b/src/markdown/style/assign.js
@@ -1,5 +1,6 @@
 /** @module */
 import postcss from 'postcss'
+import marpitPlugin from '../marpit_plugin'
 
 const uniqKeyChars =
   'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
@@ -90,4 +91,4 @@ function assign(md, marpit, opts = {}) {
   })
 }
 
-export default assign
+export default marpitPlugin(assign)

--- a/src/markdown/style/assign.js
+++ b/src/markdown/style/assign.js
@@ -38,12 +38,12 @@ const injectScopePostCSSplugin = postcss.plugin(
  *
  * @alias module:markdown/style/assign
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  * @param {Object} [opts]
  * @param {boolean} [opts.supportScoped=true] Setting whether support scoped
  *     style.
  */
-function assign(md, marpit, opts = {}) {
+function assign(md, opts = {}) {
+  const { marpit } = md
   const shouldSupportScoped =
     'supportScoped' in opts ? !!opts.supportScoped : true
 

--- a/src/markdown/style/parse.js
+++ b/src/markdown/style/parse.js
@@ -1,4 +1,6 @@
 /** @module */
+import marpitPlugin from '../marpit_plugin'
+
 const styleMatcher = /<style([\s\S]*?)>([\s\S]*?)<\/style>/i
 const styleMatcherOpening = /^<style(?=(\s|>|$))/i
 const styleMatcherClosing = /<\/style>/i
@@ -77,4 +79,4 @@ function parse(md, marpit) {
   )
 }
 
-export default parse
+export default marpitPlugin(parse)

--- a/src/markdown/style/parse.js
+++ b/src/markdown/style/parse.js
@@ -17,9 +17,10 @@ const styleMatcherScoped = /\bscoped\b/i
  *
  * @alias module:markdown/style/parse
  * @param {MarkdownIt} md markdown-it instance.
- * @param {Marpit} marpit Marpit instance.
  */
-function parse(md, marpit) {
+function parse(md) {
+  const { marpit } = md
+
   /**
    * Based on markdown-it html_block rule
    * https://github.com/markdown-it/markdown-it/blob/master/lib/rules_block/html_block.js

--- a/src/markdown/style/parse.js
+++ b/src/markdown/style/parse.js
@@ -29,7 +29,7 @@ function parse(md) {
     'html_block',
     'marpit_style_parse',
     (state, startLine, endLine, silent) => {
-      if (!marpit.options.inlineStyle) return false
+      if (marpit.options.inlineStyle === false) return false
 
       // Fast fail
       let pos = state.bMarks[startLine] + state.tShift[startLine]

--- a/src/markdown/sweep.js
+++ b/src/markdown/sweep.js
@@ -1,4 +1,5 @@
 /** @module */
+import marpitPlugin from './marpit_plugin'
 
 /**
  * Marpit sweep plugin.
@@ -56,4 +57,4 @@ function sweep(md) {
   })
 }
 
-export default sweep
+export default marpitPlugin(sweep)

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -175,20 +175,20 @@ class Marpit {
     const { filters, looseYAML, scopedStyle } = this.options
 
     md.use(marpitComment, { looseYAML })
-      .use(marpitStyleParse, this)
+      .use(marpitStyleParse)
       .use(marpitSlide)
-      .use(marpitParseDirectives, this, { looseYAML })
-      .use(marpitApplyDirectives, this)
+      .use(marpitParseDirectives, { looseYAML })
+      .use(marpitApplyDirectives)
       .use(marpitHeaderAndFooter)
-      .use(marpitHeadingDivider, this)
+      .use(marpitHeadingDivider)
       .use(marpitSlideContainer, this.slideContainers)
       .use(marpitContainerPlugin, this.containers)
       .use(marpitParseImage, { filters })
       .use(marpitSweep)
-      .use(marpitInlineSVG, this)
-      .use(marpitStyleAssign, this, { supportScoped: scopedStyle })
-      .use(marpitCollect, this)
-      .use(marpitBackgroundImage, this)
+      .use(marpitInlineSVG)
+      .use(marpitStyleAssign, { supportScoped: scopedStyle })
+      .use(marpitCollect)
+      .use(marpitBackgroundImage)
   }
 
   /**

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -53,6 +53,8 @@ const warnDeprecatedOpts = opts => {
  * Parse Marpit Markdown and render to the slide HTML/CSS.
  */
 class Marpit {
+  #markdown = undefined
+
   /**
    * Create a Marpit instance.
    *
@@ -133,11 +135,25 @@ class Marpit {
      */
     this.themeSet = new ThemeSet()
 
-    /**
-     * @type {MarkdownIt}
-     */
-    this.markdown = new MarkdownIt(...wrapArray(this.options.markdown))
-    this.applyMarkdownItPlugins()
+    this.applyMarkdownItPlugins(
+      new MarkdownIt(...wrapArray(this.options.markdown))
+    )
+  }
+
+  /**
+   * @type {MarkdownIt}
+   */
+  get markdown() {
+    return this.#markdown
+  }
+
+  set markdown(md) {
+    if (this.#markdown && this.#markdown.marpit) delete this.#markdown.marpit
+    this.#markdown = md
+
+    if (md) {
+      Object.defineProperty(md, 'marpit', { configurable: true, value: this })
+    }
   }
 
   /**
@@ -153,7 +169,9 @@ class Marpit {
   }
 
   /** @private */
-  applyMarkdownItPlugins(md = this.markdown) {
+  applyMarkdownItPlugins(md) {
+    this.markdown = md
+
     const { filters, looseYAML, scopedStyle } = this.options
 
     md.use(marpitComment, { looseYAML })

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -124,12 +124,6 @@ class Marpit {
       value: Object.seal({ global: {}, local: {} }),
     })
 
-    // Internal members
-    Object.defineProperties(this, {
-      containers: { value: [...wrapArray(this.options.container)] },
-      slideContainers: { value: [...wrapArray(this.options.slideContainer)] },
-    })
-
     /**
      * @type {ThemeSet}
      */
@@ -172,21 +166,19 @@ class Marpit {
   applyMarkdownItPlugins(md) {
     this.markdown = md
 
-    const { filters, looseYAML, scopedStyle } = this.options
-
-    md.use(marpitComment, { looseYAML })
+    md.use(marpitComment)
       .use(marpitStyleParse)
       .use(marpitSlide)
-      .use(marpitParseDirectives, { looseYAML })
+      .use(marpitParseDirectives)
       .use(marpitApplyDirectives)
       .use(marpitHeaderAndFooter)
       .use(marpitHeadingDivider)
-      .use(marpitSlideContainer, this.slideContainers)
-      .use(marpitContainerPlugin, this.containers)
-      .use(marpitParseImage, { filters })
+      .use(marpitSlideContainer)
+      .use(marpitContainerPlugin)
+      .use(marpitParseImage)
       .use(marpitSweep)
       .use(marpitInlineSVG)
-      .use(marpitStyleAssign, { supportScoped: scopedStyle })
+      .use(marpitStyleAssign)
       .use(marpitCollect)
       .use(marpitBackgroundImage)
   }
@@ -258,7 +250,10 @@ class Marpit {
   themeSetPackOptions() {
     return {
       after: this.lastStyles ? this.lastStyles.join('\n') : undefined,
-      containers: [...this.containers, ...this.slideContainers],
+      containers: [
+        ...wrapArray(this.options.container),
+        ...wrapArray(this.options.slideContainer),
+      ],
       inlineSVG: this.options.inlineSVG,
       printable: this.options.printable,
     }

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -15,20 +15,21 @@ describe('Marpit background image plugin', () => {
     customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
     themeSet: { getThemeProp: () => 100 },
-    options: { backgroundSyntax: true, inlineSVG: svg },
+    options: { backgroundSyntax: true, filters: true, inlineSVG: svg },
   })
 
-  const md = (svg = false, filters = false) => {
-    const stub = marpitStub(svg)
+  const md = (svg = false) => {
+    const instance = new MarkdownIt()
+    instance.marpit = marpitStub(svg)
 
-    return new MarkdownIt()
+    return instance
       .use(comment)
       .use(slide)
-      .use(parseDirectives, stub)
-      .use(applyDirectives, stub)
-      .use(inlineSVG, stub)
-      .use(parseImage, { filters })
-      .use(backgroundImage, stub)
+      .use(parseDirectives)
+      .use(applyDirectives)
+      .use(inlineSVG)
+      .use(parseImage)
+      .use(backgroundImage)
   }
 
   const bgDirective = (url, mdInstance) => {
@@ -132,7 +133,7 @@ describe('Marpit background image plugin', () => {
   })
 
   context('with inline SVG (Advanced background mode)', () => {
-    const mdSVG = (filters = false) => md(true, filters)
+    const mdSVG = () => md(true)
     const $load = html =>
       cheerio.load(html, {
         lowerCaseAttributeNames: false,
@@ -293,7 +294,7 @@ describe('Marpit background image plugin', () => {
       })
     })
 
-    context('when filters option of parse image plugin is enabled', () => {
+    describe('CSS Filters', () => {
       it('assigns filter style with the function of filter', () => {
         const filters = {
           // with default attributes
@@ -329,9 +330,7 @@ describe('Marpit background image plugin', () => {
         }
 
         Object.keys(filters).forEach(filter => {
-          const $ = $load(
-            mdSVG(true).render(`![${filter}](a)\n![bg ${filter}](b)`)
-          )
+          const $ = $load(mdSVG().render(`![${filter}](a)\n![bg ${filter}](b)`))
           const inlineImageStyle = $('img').attr('style')
           const bgImageStyle = $('img').attr('style')
 
@@ -365,7 +364,7 @@ describe('Marpit background image plugin', () => {
         )
 
         Object.keys(injections).forEach(filter => {
-          const $ = $load(mdSVG(true).render(`![${filter}](a)`))
+          const $ = $load(mdSVG().render(`![${filter}](a)`))
           const style = $('img').attr('style')
 
           expect(style).toBe(injections[filter])

--- a/test/markdown/collect.js
+++ b/test/markdown/collect.js
@@ -18,17 +18,18 @@ describe('Marpit collect plugin', () => {
     options: { inlineSVG: svg },
   })
 
-  const md = marpitInstance =>
-    new MarkdownIt('commonmark')
+  const md = marpitInstance => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = marpitInstance
+
+    return instance
       .use(comment)
       .use(slide)
-      .use(parseDirectives, {
-        customDirectives: marpitInstance.customDirectives,
-        themeSet: marpitInstance.themeSet,
-      })
-      .use(applyDirectives, marpitInstance)
-      .use(collect, marpitInstance)
-      .use(inlineSVG, marpitInstance)
+      .use(parseDirectives)
+      .use(applyDirectives)
+      .use(collect)
+      .use(inlineSVG)
+  }
 
   const text = dedent`
     ---

--- a/test/markdown/comment.js
+++ b/test/markdown/comment.js
@@ -4,8 +4,12 @@ import MarkdownIt from 'markdown-it'
 import comment from '../../src/markdown/comment'
 
 describe('Marpit comment plugin', () => {
-  const md = (mdOption = {}) =>
-    new MarkdownIt('commonmark', mdOption).use(comment)
+  const md = (mdOption = {}) => {
+    const instance = new MarkdownIt('commonmark', mdOption)
+    instance.marpit = { options: {} }
+
+    return instance.use(comment)
+  }
 
   const text = dedent`
     # foo

--- a/test/markdown/container.js
+++ b/test/markdown/container.js
@@ -4,7 +4,12 @@ import { Element } from '../../src/index'
 import container from '../../src/markdown/container'
 
 describe('Marpit container plugin', () => {
-  const md = (...args) => new MarkdownIt('commonmark').use(container, ...args)
+  const md = containers => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = { options: { container: containers } }
+
+    return instance.use(container)
+  }
 
   context('with empty', () => {
     it('has no effect on rendered HTML', () => {

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -12,12 +12,19 @@ describe('Marpit directives apply plugin', () => {
 
   const md = (...args) => {
     const customDirectives = { global: {}, local: {} }
+    const instance = new MarkdownIt('commonmark')
 
-    return new MarkdownIt('commonmark')
+    instance.marpit = {
+      customDirectives,
+      options: { looseYAML: false },
+      themeSet: themeSetStub,
+    }
+
+    return instance
       .use(comment)
       .use(slide)
-      .use(parseDirectives, { customDirectives, themeSet: themeSetStub })
-      .use(applyDirectives, { customDirectives }, ...args)
+      .use(parseDirectives)
+      .use(applyDirectives, ...args)
   }
 
   const mdForTest = (...args) =>

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -8,15 +8,20 @@ describe('Marpit directives parse plugin', () => {
   const themeSetStub = new Map()
   const marpitStub = {
     customDirectives: { global: {}, local: {} },
+    options: { looseYAML: false },
     themeSet: themeSetStub,
   }
   themeSetStub.set('test_theme', true)
 
-  const md = (...args) =>
-    new MarkdownIt('commonmark')
+  const md = (...args) => {
+    const instance = MarkdownIt('commonmark')
+    instance.marpit = marpitStub
+
+    return instance
       .use(comment)
       .use(slide)
-      .use(parseDirectives, marpitStub, ...args)
+      .use(parseDirectives, ...args)
+  }
 
   context('with frontMatter option', () => {
     const text = dedent`

--- a/test/markdown/header_and_footer.js
+++ b/test/markdown/header_and_footer.js
@@ -14,19 +14,21 @@ describe('Marpit header and footer plugin', () => {
     themeSet,
     customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
+    options: {},
     ...props,
   })
 
-  const md = (marpitInstance = marpitStub()) =>
-    new MarkdownIt('commonmark')
+  const md = (marpitInstance = marpitStub()) => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = marpitInstance
+
+    return instance
       .use(comment)
       .use(slide)
-      .use(parseDirectives, {
-        customDirectives: marpitInstance.customDirectives,
-        themeSet: marpitInstance.themeSet,
-      })
-      .use(applyDirectives, marpitInstance)
+      .use(parseDirectives)
+      .use(applyDirectives)
       .use(headerAndFooter)
+  }
 
   describe('Header local directive', () => {
     const markdown = header =>

--- a/test/markdown/heading_divider.js
+++ b/test/markdown/heading_divider.js
@@ -19,10 +19,14 @@ describe('Marpit heading divider plugin', () => {
     )
 
   describe('Constructor option', () => {
-    const md = marpitInstance =>
-      new MarkdownIt('commonmark')
+    const md = marpitInstance => {
+      const instance = new MarkdownIt('commonmark')
+      instance.marpit = marpitInstance
+
+      return instance
         .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))
-        .use(headingDivider, marpitInstance)
+        .use(headingDivider)
+    }
 
     context('with headingDivider option as false', () => {
       const markdown = md(marpitStub(false))
@@ -87,8 +91,12 @@ describe('Marpit heading divider plugin', () => {
     })
 
     context('with headingDivider option as 4 and slide plugin', () => {
-      const mdWithSlide = instance =>
-        new MarkdownIt('commonmark').use(slide).use(headingDivider, instance)
+      const mdWithSlide = marpitInstance => {
+        const instance = new MarkdownIt('commonmark')
+        instance.marpit = marpitInstance
+
+        return instance.use(slide).use(headingDivider)
+      }
 
       it('renders four <section> elements', () => {
         const $ = cheerio.load(mdWithSlide(marpitStub(4)).render(markdownText))
@@ -112,12 +120,16 @@ describe('Marpit heading divider plugin', () => {
         customDirectives: { global: {}, local: {} },
         options: {},
       }
-    ) =>
-      new MarkdownIt('commonmark')
+    ) => {
+      const instance = new MarkdownIt('commonmark')
+      instance.marpit = marpitInstance
+
+      return instance
         .use(comment)
         .use(pluginMd => pluginMd.core.ruler.push('marpit_slide', () => {}))
-        .use(parseDirectives, marpitInstance)
-        .use(headingDivider, marpitInstance)
+        .use(parseDirectives)
+        .use(headingDivider)
+    }
 
     const markdownTextWithDirective = level =>
       `---\nheadingDivider: ${level}\n---\n\n${markdownText}`

--- a/test/markdown/inline_svg.js
+++ b/test/markdown/inline_svg.js
@@ -1,7 +1,5 @@
 import cheerio from 'cheerio'
 import MarkdownIt from 'markdown-it'
-import applyDirectives from '../../src/markdown/directives/apply'
-import parseDirectives from '../../src/markdown/directives/parse'
 import slide from '../../src/markdown/slide'
 import inlineSVG from '../../src/markdown/inline_svg'
 import { Theme, ThemeSet } from '../../src/index'
@@ -15,15 +13,17 @@ describe('Marpit inline SVG plugin', () => {
     ...props,
   })
 
-  const md = (marpitInstance = marpitStub()) =>
-    new MarkdownIt('commonmark')
+  const md = (marpitInstance = marpitStub()) => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = marpitInstance
+
+    return instance
       .use(slide)
-      .use(parseDirectives, {
-        customDirectives: marpitInstance.customDirectives,
-        themeSet: marpitInstance.themeSet,
-      })
-      .use(applyDirectives, marpitInstance)
-      .use(inlineSVG, marpitInstance)
+      .use(pluginMd =>
+        pluginMd.core.ruler.push('marpit_directives_parse', () => {})
+      )
+      .use(inlineSVG)
+  }
 
   const render = (markdownIt, text, inline = false) => {
     const method = inline ? markdownIt.renderInline : markdownIt.render

--- a/test/markdown/parse_image.js
+++ b/test/markdown/parse_image.js
@@ -3,7 +3,12 @@ import MarkdownIt from 'markdown-it'
 import parseImage from '../../src/markdown/parse_image'
 
 describe('Marpit parse image plugin', () => {
-  const md = (opts = {}) => new MarkdownIt('commonmark').use(parseImage, opts)
+  const md = () => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = { options: {} }
+
+    return instance.use(parseImage)
+  }
 
   const style = opts => {
     const $ = cheerio.load(
@@ -12,50 +17,48 @@ describe('Marpit parse image plugin', () => {
     return $('img').attr('style')
   }
 
-  context('with width option', () => {
-    it('renders image width style', () => {
-      // Number & floats
-      expect(style('w:100')).toBe('width:100px;')
-      expect(style('width:23.4')).toBe('width:23.4px;')
-      expect(style('w:.5')).toBe('width:.5px;')
+  it('renders image width style', () => {
+    // Number & floats
+    expect(style('w:100')).toBe('width:100px;')
+    expect(style('width:23.4')).toBe('width:23.4px;')
+    expect(style('w:.5')).toBe('width:.5px;')
 
-      // CSS units
-      expect(style('w:1ch')).toBe('width:1ch;')
-      expect(style('w:2cm')).toBe('width:2cm;')
-      expect(style('w:3em')).toBe('width:3em;')
-      expect(style('w:4ex')).toBe('width:4ex;')
-      expect(style('w:5in')).toBe('width:5in;')
-      expect(style('w:6mm')).toBe('width:6mm;')
-      expect(style('w:7pc')).toBe('width:7pc;')
-      expect(style('w:8pt')).toBe('width:8pt;')
-      expect(style('w:9px')).toBe('width:9px;')
+    // CSS units
+    expect(style('w:1ch')).toBe('width:1ch;')
+    expect(style('w:2cm')).toBe('width:2cm;')
+    expect(style('w:3em')).toBe('width:3em;')
+    expect(style('w:4ex')).toBe('width:4ex;')
+    expect(style('w:5in')).toBe('width:5in;')
+    expect(style('w:6mm')).toBe('width:6mm;')
+    expect(style('w:7pc')).toBe('width:7pc;')
+    expect(style('w:8pt')).toBe('width:8pt;')
+    expect(style('w:9px')).toBe('width:9px;')
 
-      // Percentage and not supported keyword in inline image will ignore
-      expect(style('w:100%')).not.toBe('width:100%;')
-      expect(style('w:12.345%')).not.toBe('width:12.345%;')
-      expect(style('w:.678%')).not.toBe('width:.678%;')
-      expect(style('w:unexpected')).not.toBe('width:unexpected;')
-    })
+    // Percentage and not supported keyword in inline image will ignore
+    expect(style('w:100%')).not.toBe('width:100%;')
+    expect(style('w:12.345%')).not.toBe('width:12.345%;')
+    expect(style('w:.678%')).not.toBe('width:.678%;')
+    expect(style('w:unexpected')).not.toBe('width:unexpected;')
+  })
 
-    it('renders image height style', () => {
-      expect(style('h:100')).toBe('height:100px;')
-      expect(style('height:23.4')).toBe('height:23.4px;')
-      expect(style('h:.5')).toBe('height:.5px;')
+  it('renders image height style', () => {
+    expect(style('h:100')).toBe('height:100px;')
+    expect(style('height:23.4')).toBe('height:23.4px;')
+    expect(style('h:.5')).toBe('height:.5px;')
 
-      expect(style('h:1ch')).toBe('height:1ch;')
-      expect(style('h:2cm')).toBe('height:2cm;')
-      expect(style('h:3em')).toBe('height:3em;')
-      expect(style('h:4ex')).toBe('height:4ex;')
-      expect(style('h:5in')).toBe('height:5in;')
-      expect(style('h:6mm')).toBe('height:6mm;')
-      expect(style('h:7pc')).toBe('height:7pc;')
-      expect(style('h:8pt')).toBe('height:8pt;')
-      expect(style('h:9px')).toBe('height:9px;')
+    expect(style('h:1ch')).toBe('height:1ch;')
+    expect(style('h:2cm')).toBe('height:2cm;')
+    expect(style('h:3em')).toBe('height:3em;')
+    expect(style('h:4ex')).toBe('height:4ex;')
+    expect(style('h:5in')).toBe('height:5in;')
+    expect(style('h:6mm')).toBe('height:6mm;')
+    expect(style('h:7pc')).toBe('height:7pc;')
+    expect(style('h:8pt')).toBe('height:8pt;')
+    expect(style('h:9px')).toBe('height:9px;')
 
-      expect(style('h:100%')).not.toBe('height:100%;')
-      expect(style('h:12.345%')).not.toBe('height:12.345%;')
-      expect(style('h:.678%')).not.toBe('height:.678%;')
-      expect(style('w:unexpected')).not.toBe('width:unexpected;')
-    })
+    expect(style('h:100%')).not.toBe('height:100%;')
+    expect(style('h:12.345%')).not.toBe('height:12.345%;')
+    expect(style('h:.678%')).not.toBe('height:.678%;')
+    expect(style('h:unexpected')).not.toBe('height:unexpected;')
   })
 })

--- a/test/markdown/slide.js
+++ b/test/markdown/slide.js
@@ -3,7 +3,12 @@ import MarkdownIt from 'markdown-it'
 import slide from '../../src/markdown/slide'
 
 describe('Marpit slide plugin', () => {
-  const md = (...args) => new MarkdownIt('commonmark').use(slide, ...args)
+  const md = (...args) => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = {}
+
+    return instance.use(slide, ...args)
+  }
 
   context('with default options', () => {
     const markdown = md()

--- a/test/markdown/slide_container.js
+++ b/test/markdown/slide_container.js
@@ -5,8 +5,12 @@ import slide from '../../src/markdown/slide'
 import slideContainer from '../../src/markdown/slide_container'
 
 describe('Marpit slide container plugin', () => {
-  const md = (...args) =>
-    new MarkdownIt('commonmark').use(slide).use(slideContainer, ...args)
+  const md = containers => {
+    const instance = new MarkdownIt('commonmark')
+    instance.marpit = { options: { slideContainer: containers } }
+
+    return instance.use(slide).use(slideContainer)
+  }
 
   context('with empty', () => {
     it('has no effect on rendered HTML', () => {

--- a/test/markdown/style/assign.js
+++ b/test/markdown/style/assign.js
@@ -9,19 +9,22 @@ import styleAssign from '../../../src/markdown/style/assign'
 import styleParse from '../../../src/markdown/style/parse'
 
 describe('Marpit style assign plugin', () => {
-  const marpitStub = (...opts) => ({
+  const marpitStub = () => ({
     customDirectives: { global: {}, local: {} },
-    options: { inlineStyle: true },
+    options: {},
     themeSet: new Map(),
-    ...opts,
   })
 
   context('with inline style elements', () => {
-    const md = (marpit, opts = {}) =>
-      new MarkdownIt('commonmark')
+    const md = marpit => {
+      const instance = new MarkdownIt('commonmark')
+      instance.marpit = marpit
+
+      return instance
         .use(slide)
-        .use(styleParse, marpit)
-        .use(styleAssign, marpit, opts)
+        .use(styleParse)
+        .use(styleAssign)
+    }
 
     it('assigns parsed styles to Marpit lastStyles property', () => {
       const marpit = marpitStub()
@@ -92,26 +95,21 @@ describe('Marpit style assign plugin', () => {
           expect(marpit.lastStyles).toHaveLength(0)
         })
       })
-
-      context('when supportScoped option is setting as false', () => {
-        const marpit = marpitStub()
-        const opts = { supportScoped: false }
-        md(marpit, opts).render('<style scoped>b { color: red; }</style>')
-
-        const [style] = marpit.lastStyles
-        expect(style).not.toContain('data-marpit-scope')
-      })
     })
   })
 
   context('with style global directive', () => {
-    const md = marpit =>
-      new MarkdownIt('commonmark')
+    const md = marpit => {
+      const instance = new MarkdownIt('commonmark')
+      instance.marpit = marpit
+
+      return instance
         .use(comment)
         .use(slide)
-        .use(parseDirectives, marpit)
-        .use(applyDirectives, marpit)
-        .use(styleAssign, marpit)
+        .use(parseDirectives)
+        .use(applyDirectives)
+        .use(styleAssign)
+    }
 
     it('assigns parsed style global directive to Marpit lastStyles property', () => {
       const marpit = marpitStub()
@@ -126,14 +124,18 @@ describe('Marpit style assign plugin', () => {
   })
 
   context('with muiltiple style elements and a style directive', () => {
-    const md = marpit =>
-      new MarkdownIt('commonmark')
+    const md = marpit => {
+      const instance = new MarkdownIt('commonmark')
+      instance.marpit = marpit
+
+      return instance
         .use(comment)
-        .use(styleParse, marpit)
+        .use(styleParse)
         .use(slide)
-        .use(parseDirectives, marpit)
-        .use(applyDirectives, marpit)
-        .use(styleAssign, marpit)
+        .use(parseDirectives)
+        .use(applyDirectives)
+        .use(styleAssign)
+    }
 
     it('assigns inline styles prior to directive style', () => {
       const marpit = marpitStub()

--- a/test/markdown/style/parse.js
+++ b/test/markdown/style/parse.js
@@ -4,9 +4,13 @@ import MarkdownIt from 'markdown-it'
 import styleParse from '../../../src/markdown/style/parse'
 
 describe('Marpit style parse plugin', () => {
-  const marpitStub = { options: { inlineStyle: true } }
-  const md = (marpit = marpitStub, mdOption = {}) =>
-    new MarkdownIt('commonmark', mdOption).use(styleParse, marpit)
+  const marpitStub = { options: {} }
+  const md = (marpit = marpitStub, mdOption = {}) => {
+    const instance = new MarkdownIt('commonmark', mdOption)
+    instance.marpit = marpit
+
+    return instance.use(styleParse)
+  }
 
   it("ignores parse when Marpit's inlineStyle option is false", () => {
     const types = md({ options: { inlineStyle: false } })

--- a/test/markdown/sweep.js
+++ b/test/markdown/sweep.js
@@ -11,7 +11,12 @@ import slide from '../../src/markdown/slide'
 import sweep from '../../src/markdown/sweep'
 
 describe('Marpit sweep plugin', () => {
-  const md = (opts = {}) => new MarkdownIt('commonmark', opts).use(sweep)
+  const md = (mdOpts = {}, marpitInstance = { options: {} }) => {
+    const instance = new MarkdownIt('commonmark', mdOpts)
+    instance.marpit = marpitInstance
+
+    return instance.use(sweep)
+  }
 
   it('does not sweep whitespace in #renderInline', () =>
     expect(md().renderInline(' ')).toBe(' '))
@@ -23,13 +28,13 @@ describe('Marpit sweep plugin', () => {
       options: { backgroundSyntax: true, inlineSVG: false },
     }
 
-    const markdown = md({ breaks: true })
+    const markdown = md({ breaks: true }, marpitStub)
       .use(slide)
-      .use(parseDirectives, marpitStub)
-      .use(applyDirectives, marpitStub)
-      .use(inlineSVG, marpitStub)
+      .use(parseDirectives)
+      .use(applyDirectives)
+      .use(inlineSVG)
       .use(parseImage)
-      .use(backgroundImage, marpitStub)
+      .use(backgroundImage)
 
     const $ = cheerio.load(
       markdown.render(dedent`

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -93,8 +93,10 @@ describe('Marpit', () => {
       marpit.themeSet.add('/* @theme foobar */')
 
       const md = new MarkdownIt().use(marpit.markdownItPlugins)
-      md.render('<!-- theme: foobar -->')
+      expect(marpit.markdown).toBe(md)
+      expect(md.marpit).toBe(marpit)
 
+      md.render('<!-- theme: foobar -->')
       expect(marpit.lastGlobalDirectives.theme).toBe('foobar')
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,18 @@
     "@babel/traverse" "^7.4.0"
     "@babel/types" "^7.4.0"
 
+"@babel/helper-create-class-features-plugin@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz#30fd090e059d021995c1762a5b76798fa0b51d82"
+  integrity sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.4.0"
+    "@babel/helper-split-export-declaration" "^7.4.0"
+
 "@babel/helper-define-map@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz#cbfd8c1b2f12708e262c26f600cd16ed6a3bc6c9"
@@ -244,6 +256,14 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
+"@babel/plugin-proposal-class-properties@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz#d70db61a2f1fd79de927eea91f6411c964e084b8"
+  integrity sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.4.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
@@ -267,6 +287,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-private-methods@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.4.0.tgz#7baebf9655dd6b5eb37533e5305704f4fbf6d458"
+  integrity sha512-9OX8dx3upaiwYDPbgwS2e/CuytiTYfsfOxdczLXTCnNjD3lGMUgIW4B6puHk/EAuu+KXnRTLsvzh63BD1w4FEg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.4.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.4.0":
   version "7.4.0"
@@ -1179,6 +1207,18 @@ babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
+
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-jest@^24.5.0:
   version "24.5.0"
@@ -2511,6 +2551,14 @@ eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
   integrity sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Now, Marpit plugins require injected `marpit` member into markdown-it instance. We've updated plugins to use injected instance for reading Marpit options.

We think that rarely happen this case, but you won't have to care params when use Marpit plugins individually. Just inject Marpit instance to `marpit` member.

```javascript
const markdownit = new MarkdownIt()
markdownit.marpit = new Marpit()
markdownit.use(marpitSlide)
```

If you were using `marpit.markdownItPlugins` interface, `marpit.markdown` and `markdownit.marpit` would be updated to the last injected markdown-it/Marpit instance.

```javascript
const marpit = new Marpit()
const markdownit = new MarkdownIt().use(marpit.markdownItPlugins)
// (marpit === markdownit.marpit && markdownit === marpit.markdown) === true
```

The purpose of this change is to prepare building an escape hatch of deprecated options. By injecting opinionated feature by individual plugins instead of controlling plugin's feature by Marpit options, the power user may build custom Marpit from a plain markdown-it instance with just picking favorite plugins. However, there is not a desire like that at this moment, so we won't work splitting plugins actively now.