### PR TITLE
Remove deprecated constructor options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 
 - Drop support for Node 6.x ([#139](https://github.com/marp-team/marpit/issues/139), [#155](https://github.com/marp-team/marpit/pull/155))
+- Remove deprecated constructor options: `backgroundSyntax`, `filters`, `inlineStyle`, and `scopedStyle` ([#156](https://github.com/marp-team/marpit/pull/156))
 
 ## v0.9.2 - 2019-04-08
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,10 @@
 declare module '@marp-team/marpit' {
   interface MarpitOptions {
-    backgroundSyntax?: boolean
     container?: false | Element | Element[]
-    filters?: boolean
     headingDivider?: false | MarpitHeadingDivider | MarpitHeadingDivider[]
-    inlineStyle?: boolean
     looseYAML?: boolean
     markdown?: string | object | [string, object]
     printable?: boolean
-    scopedStyle?: boolean
     slideContainer?: false | Element | Element[]
     inlineSVG?: boolean
   }

--- a/src/markdown/background_image.js
+++ b/src/markdown/background_image.js
@@ -21,10 +21,6 @@ import parse from './background_image/parse'
  * @param {MarkdownIt} md markdown-it instance.
  */
 function backgroundImage(md) {
-  const { marpit } = md
-
-  if (!marpit.options.backgroundSyntax) return
-
   parse(md)
   apply(md)
   advanced(md)

--- a/src/markdown/parse_image.js
+++ b/src/markdown/parse_image.js
@@ -19,9 +19,6 @@ const escape = target =>
  * @param {MarkdownIt} md markdown-it instance.
  */
 function parseImage(md) {
-  const isEnabledFilters =
-    md.marpit.options.filters !== undefined ? md.marpit.options.filters : true
-
   const optionMatchers = new Map()
 
   // The scale percentage for resize background
@@ -38,64 +35,57 @@ function parseImage(md) {
     matches => ({ height: matches[1] })
   )
 
-  if (isEnabledFilters) {
-    // CSS filters
-    optionMatchers.set(/^blur(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['blur', escape(matches[1] || '10px')]],
-    }))
-    optionMatchers.set(/^brightness(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['brightness', escape(matches[1] || '1.5')]],
-    }))
-    optionMatchers.set(/^contrast(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['contrast', escape(matches[1] || '2')]],
-    }))
-    optionMatchers.set(
-      /^drop-shadow(?::(.+?),(.+?)(?:,(.+?))?(?:,(.+?))?)?$/,
-      (matches, meta) => {
-        const args = []
+  // CSS filters
+  optionMatchers.set(/^blur(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['blur', escape(matches[1] || '10px')]],
+  }))
+  optionMatchers.set(/^brightness(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['brightness', escape(matches[1] || '1.5')]],
+  }))
+  optionMatchers.set(/^contrast(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['contrast', escape(matches[1] || '2')]],
+  }))
+  optionMatchers.set(
+    /^drop-shadow(?::(.+?),(.+?)(?:,(.+?))?(?:,(.+?))?)?$/,
+    (matches, meta) => {
+      const args = []
 
-        for (const arg of matches.slice(1)) {
-          if (arg) {
-            const colorFunc = arg.match(/^(rgba?|hsla?)\((.*)\)$/)
+      for (const arg of matches.slice(1)) {
+        if (arg) {
+          const colorFunc = arg.match(/^(rgba?|hsla?)\((.*)\)$/)
 
-            args.push(
-              colorFunc
-                ? `${colorFunc[1]}(${escape(colorFunc[2])})`
-                : escape(arg)
-            )
-          }
-        }
-
-        return {
-          filters: [
-            ...meta.filters,
-            ['drop-shadow', args.join(' ') || '0 5px 10px rgba(0,0,0,.4)'],
-          ],
+          args.push(
+            colorFunc ? `${colorFunc[1]}(${escape(colorFunc[2])})` : escape(arg)
+          )
         }
       }
-    )
-    optionMatchers.set(/^grayscale(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['grayscale', escape(matches[1] || '1')]],
-    }))
-    optionMatchers.set(/^hue-rotate(?::(.+))?$/, (matches, meta) => ({
-      filters: [
-        ...meta.filters,
-        ['hue-rotate', escape(matches[1] || '180deg')],
-      ],
-    }))
-    optionMatchers.set(/^invert(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['invert', escape(matches[1] || '1')]],
-    }))
-    optionMatchers.set(/^opacity(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['opacity', escape(matches[1] || '.5')]],
-    }))
-    optionMatchers.set(/^saturate(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['saturate', escape(matches[1] || '2')]],
-    }))
-    optionMatchers.set(/^sepia(?::(.+))?$/, (matches, meta) => ({
-      filters: [...meta.filters, ['sepia', escape(matches[1] || '1')]],
-    }))
-  }
+
+      return {
+        filters: [
+          ...meta.filters,
+          ['drop-shadow', args.join(' ') || '0 5px 10px rgba(0,0,0,.4)'],
+        ],
+      }
+    }
+  )
+  optionMatchers.set(/^grayscale(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['grayscale', escape(matches[1] || '1')]],
+  }))
+  optionMatchers.set(/^hue-rotate(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['hue-rotate', escape(matches[1] || '180deg')]],
+  }))
+  optionMatchers.set(/^invert(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['invert', escape(matches[1] || '1')]],
+  }))
+  optionMatchers.set(/^opacity(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['opacity', escape(matches[1] || '.5')]],
+  }))
+  optionMatchers.set(/^saturate(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['saturate', escape(matches[1] || '2')]],
+  }))
+  optionMatchers.set(/^sepia(?::(.+))?$/, (matches, meta) => ({
+    filters: [...meta.filters, ['sepia', escape(matches[1] || '1')]],
+  }))
 
   md.inline.ruler2.push('marpit_parse_image', ({ tokens }) => {
     for (const token of tokens) {

--- a/src/markdown/style/assign.js
+++ b/src/markdown/style/assign.js
@@ -41,8 +41,6 @@ const injectScopePostCSSplugin = postcss.plugin(
  */
 function assign(md) {
   const { marpit } = md
-  const shouldSupportScoped =
-    marpit.options.scopedStyle !== undefined ? marpit.options.scopedStyle : true
 
   md.core.ruler.after('marpit_slide', 'marpit_style_assign', state => {
     if (state.inlineMode) return
@@ -63,7 +61,7 @@ function assign(md) {
         // Scoped style into current page
         const { marpitStyleScoped } = token.meta || {}
 
-        if (shouldSupportScoped && current && marpitStyleScoped) {
+        if (current && marpitStyleScoped) {
           let metaAttr = current.meta.marpitScopeMeta
 
           if (!metaAttr) {

--- a/src/markdown/style/parse.js
+++ b/src/markdown/style/parse.js
@@ -19,8 +19,6 @@ const styleMatcherScoped = /\bscoped\b/i
  * @param {MarkdownIt} md markdown-it instance.
  */
 function parse(md) {
-  const { marpit } = md
-
   /**
    * Based on markdown-it html_block rule
    * https://github.com/markdown-it/markdown-it/blob/master/lib/rules_block/html_block.js
@@ -29,8 +27,6 @@ function parse(md) {
     'html_block',
     'marpit_style_parse',
     (state, startLine, endLine, silent) => {
-      if (marpit.options.inlineStyle === false) return false
-
       // Fast fail
       let pos = state.bMarks[startLine] + state.tShift[startLine]
       if (state.src.charCodeAt(pos) !== 0x3c) return false

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -27,27 +27,6 @@ const defaultOptions = {
   printable: true,
   slideContainer: false,
   inlineSVG: false,
-
-  // Depreacted options
-  backgroundSyntax: true,
-  filters: true,
-  inlineStyle: true,
-  scopedStyle: true,
-}
-
-const warnDeprecatedOpts = opts => {
-  for (const opt of [
-    'backgroundSyntax',
-    'filters',
-    'inlineStyle',
-    'scopedStyle',
-  ]) {
-    if (Object.prototype.hasOwnProperty.call(opts, opt)) {
-      console.warn(
-        `Deprecation warning: ${opt} option has been deprecated and would not be able to disable in v1.x.x.`
-      )
-    }
-  }
 }
 
 /**
@@ -75,25 +54,8 @@ class Marpit {
    *     wrapping each slide sections.
    * @param {boolean} [opts.inlineSVG=false] Wrap each sections by inline SVG.
    *     _(Experimental)_
-   *
-   * @param {boolean} [opts.backgroundSyntax=true] *[DEPREACTED]* Support
-   *     markdown image syntax with the alternate text including `bg`. Normally
-   *     it converts into spot directives about background image. If `inlineSVG`
-   *     is enabled, it supports the advanced backgrounds.
-   * @param {boolean} [opts.filters=true] *[DEPREACTED]*  Support filter syntax
-   *     for markdown image. It can apply to inline image and the advanced
-   *     backgrounds.
-   * @param {boolean} [opts.inlineStyle=true] *[DEPREACTED]* Recognize `<style>`
-   *     elements to append additional styles to theme. When it is `true`,
-   *     Marpit will parse style regardless markdown-it's `html` option.
-   * @param {boolean} [opts.scopedStyle=true] *[DEPREACTED]*  Support scoping
-   *     inline style to the current slide through `<style scoped>` when
-   *     `inlineStyle` is enabled.
    */
   constructor(opts = {}) {
-    // Output warning of deprecated option
-    warnDeprecatedOpts(opts)
-
     /**
      * The current options for this instance.
      *

--- a/test/markdown/background_image.js
+++ b/test/markdown/background_image.js
@@ -15,7 +15,7 @@ describe('Marpit background image plugin', () => {
     customDirectives: { global: {}, local: {} },
     lastGlobalDirectives: {},
     themeSet: { getThemeProp: () => 100 },
-    options: { backgroundSyntax: true, filters: true, inlineSVG: svg },
+    options: { inlineSVG: svg },
   })
 
   const md = (svg = false) => {

--- a/test/markdown/style/parse.js
+++ b/test/markdown/style/parse.js
@@ -12,14 +12,6 @@ describe('Marpit style parse plugin', () => {
     return instance.use(styleParse)
   }
 
-  it("ignores parse when Marpit's inlineStyle option is false", () => {
-    const types = md({ options: { inlineStyle: false } })
-      .parse('<style>b { color: #000; }</style>')
-      .map(t => t.type)
-
-    expect(types).toStrictEqual(expect.not.arrayContaining(['marpit_style']))
-  })
-
   const text = dedent`
     <style>strong { color: red; }</style>
 

--- a/test/markdown/sweep.js
+++ b/test/markdown/sweep.js
@@ -25,7 +25,7 @@ describe('Marpit sweep plugin', () => {
     const marpitStub = {
       customDirectives: { global: {}, local: {} },
       themeSet: new Map(),
-      options: { backgroundSyntax: true, inlineSVG: false },
+      options: { inlineSVG: false },
     }
 
     const markdown = md({ breaks: true }, marpitStub)


### PR DESCRIPTION
Marpit v0.9.x has marked some constructor options as deprecated to get more simple interface than the other presentation framework. This PR will remove them.