### PR TITLE
Test with Node 12 (Erbium)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,4 +83,4 @@ workflows:
     jobs:
       - 10.15.3
       - carbon
-      # - erbium
+      - erbium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Add [documentation of fragmented list](https://marpit.marp.app/fragmented-list) ([#152](https://github.com/marp-team/marpit/pull/152))
+- Test with Node 12 (Erbium) ([#160](https://github.com/marp-team/marpit/pull/160))
 
 ### Changed
 


### PR DESCRIPTION
Now Marpit is working well in Node 12 by update of #158. So we've enabled CI testing for Node 12 (Erbium).