### PR TITLE
Automate GitHub release by marp-team common script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
     docker:
       - image: circleci/node:12
 
-  release:
+  github-release:
     <<: *base
     steps:
       - checkout
@@ -92,7 +92,8 @@ workflows:
       - current
       - carbon
       - erbium
-      - release:
+      - github-release:
+          context: github-release
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 references:
   base: &base
+    docker:
+      - image: circleci/node:10.15.3
     working_directory: ~/marpit
     steps:
       - run: node --version
@@ -62,10 +64,8 @@ references:
 
 version: 2
 jobs:
-  '10.15.3':
+  current:
     <<: *base
-    docker:
-      - image: circleci/node:10.15.3
 
   carbon:
     <<: *base
@@ -77,10 +77,24 @@ jobs:
     docker:
       - image: circleci/node:12
 
+  release:
+    <<: *base
+    steps:
+      - checkout
+      - run:
+          name: Create release on GitHub
+          command: curl https://raw.githubusercontent.com/marp-team/marp/automate-github-release/github-release.js | node
+
 workflows:
   version: 2
   build:
     jobs:
-      - 10.15.3
+      - current
       - carbon
       - erbium
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
Automate GitHub release by using common script added to entrance repository marp-team/marp#15.

Currently we use a forked branch to check behavior of script. It would apply from next release. We will update to use master branch if has confirmed script to work correctly.