### PR TITLE
Allow passing markdown-it instance as markdown constructor option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Deprecated
 
-- A plugin interface for markdown-it (`markdownItPlugins`) is deprecated in favor of added contructor option ([#164](https://github.com/marp-team/marpit/pull/164))
+- A plugin interface for markdown-it (`markdownItPlugins`) is deprecated ([#164](https://github.com/marp-team/marpit/pull/164))
 
 ## v1.0.0 - 2019-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow passing markdown-it instance as `markdown` constructor option ([#164](https://github.com/marp-team/marpit/pull/164))
+
+### Deprecated
+
+- A plugin interface for markdown-it (`markdownItPlugins`) is deprecated in favor of added contructor option ([#164](https://github.com/marp-team/marpit/pull/164))
+
 ## v1.0.0 - 2019-05-05
 
 ### Breaking

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare module '@marp-team/marpit' {
     }
     readonly options: MarpitOptions
 
-    /** @deprecated A plugin interface for markdown-it is deprecated and will remove in next major version. Instead, wrap markdown-it instance when creating Marpit by `new Marpit({ markdown: markdownItInstance })`. */
+    /** @deprecated A plugin interface for markdown-it is deprecated and will remove in future version. Instead, wrap markdown-it instance when creating Marpit by `new Marpit({ markdown: markdownItInstance })`. */
     readonly markdownItPlugins: (md: any) => void
 
     protected lastComments?: MarpitRenderResult['comments']

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare module '@marp-team/marpit' {
     container?: false | Element | Element[]
     headingDivider?: false | MarpitHeadingDivider | MarpitHeadingDivider[]
     looseYAML?: boolean
-    markdown?: string | object | [string, object]
+    markdown?: any
     printable?: boolean
     slideContainer?: false | Element | Element[]
     inlineSVG?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,8 @@ declare module '@marp-team/marpit' {
       local: MarpitDirectiveDefinitions
     }
     readonly options: MarpitOptions
+
+    /** @deprecated A plugin interface for markdown-it is deprecated and will remove in next major version. Instead, wrap markdown-it instance when creating Marpit by `new Marpit({ markdown: markdownItInstance })`. */
     readonly markdownItPlugins: (md: any) => void
 
     protected lastComments?: MarpitRenderResult['comments']

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -48,9 +48,8 @@ class Marpit {
    *     ONLY specified levels if a number array.
    * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
    * @param {MarkdownIt|string|Object|Array} [opts.markdown] An instance of
-   *     markdown-it for wrapping. Marpit will create its instance based on
-   *     CommonMark when omitted. (NOTICE: Passing its initialize option(s) is
-   *     deprecated and won't support in next major version)
+   *     markdown-it or its constructor option(s) for wrapping. Marpit will
+   *     create its instance based on CommonMark when omitted.
    * @param {boolean} [opts.printable=true] Make style printable to PDF.
    * @param {false|Element|Element[]} [opts.slideContainer] Container element(s)
    *     wrapping each slide sections.
@@ -107,10 +106,7 @@ class Marpit {
         )
           return this.options.markdown
 
-        // DEPRECATED: Create instance with passed argument(s)
-        console.warn(
-          "Deprecation warning: Passing markdown-it arguments to Marpit's `markdown` contructor option is deprecated. Instead, please pass an instance of markdown-it."
-        )
+        // Create instance with passed argument(s)
         return new MarkdownIt(...wrapArray(this.options.markdown))
       })()
     )

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -134,7 +134,7 @@ class Marpit {
    * This is useful to integrate Marpit with the other markdown-it based parser.
    *
    * @deprecated A plugin interface for markdown-it is deprecated and will
-   *     remove in next major version. Instead, wrap markdown-it instance when
+   *     remove in future version. Instead, wrap markdown-it instance when
    *     creating Marpit by `new Marpit({ markdown: markdownItInstance })`.
    * @type {Function}
    * @readonly

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -11,11 +11,39 @@ describe('Marpit', () => {
   describe('#constructor', () => {
     const instance = new Marpit()
 
+    describe('markdown option', () => {
+      const mdText = 'Hello,\n<b>world!</b>'
+
+      it('wraps CommonMark based instance by default', () =>
+        expect(instance.render(mdText).html).toContain('<b>'))
+
+      it('wraps specified markdown-it instance', () => {
+        const markdown = new MarkdownIt()
+        const mdSpy = jest.spyOn(markdown, 'parse')
+        const { html } = new Marpit({ markdown }).render(mdText)
+
+        expect(html).not.toContain('<b>')
+        expect(mdSpy).toBeCalledWith(mdText, expect.anything())
+      })
+
+      it('wraps markdown-it instance created by passed arguments [DEPRECATED]', () => {
+        const marpitWithArg = new Marpit({ markdown: { breaks: true } })
+        expect(marpitWithArg.render(mdText).html).toContain('<br')
+        expect(marpitWithArg.render(mdText).html).not.toContain('<b>')
+
+        const marpitWithArgs = new Marpit({
+          markdown: ['commonmark', { breaks: true }],
+        })
+        expect(marpitWithArgs.render(mdText).html).toContain('<br')
+        expect(marpitWithArgs.render(mdText).html).toContain('<b>')
+      })
+    })
+
     describe('options member', () => {
       it('has default options', () => {
         expect(instance.options.container.tag).toBe('div')
         expect(instance.options.container.class).toBe('marpit')
-        expect(instance.options.markdown).toBe('commonmark')
+        expect(instance.options.markdown).toBe(undefined)
         expect(instance.options.printable).toBe(true)
         expect(instance.options.slideContainer).toBe(false)
         expect(instance.options.inlineSVG).toBe(false)
@@ -86,7 +114,7 @@ describe('Marpit', () => {
     })
   })
 
-  describe('get #markdownItPlugins', () => {
+  describe('[DEPRECATED] get #markdownItPlugins', () => {
     it('provides markdown-it plugins with its compatible interface', () => {
       const marpit = new Marpit()
       marpit.themeSet.add('/* @theme foobar */')

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -26,7 +26,7 @@ describe('Marpit', () => {
         expect(mdSpy).toBeCalledWith(mdText, expect.anything())
       })
 
-      it('wraps markdown-it instance created by passed arguments [DEPRECATED]', () => {
+      it('wraps markdown-it instance created by passed arguments', () => {
         const marpitWithArg = new Marpit({ markdown: { breaks: true } })
         expect(marpitWithArg.render(mdText).html).toContain('<br')
         expect(marpitWithArg.render(mdText).html).not.toContain('<b>')


### PR DESCRIPTION
We are organizing confused features. This PR will allow passing markdown-it instance as `markdown` constructor option, to wrap any instance by Marpit.

```javascript
const markdownIt = new MarkdownIt()
const marp = new Marp({ markdown: markdownIt })
```

As before, you can also pass markdown-it constructor options, because it considers need for YAML configuration by Marp CLI.

`markdownItPlugins` interface had difficult usage is now deprecated. It as same meaning as using added constructor option.