### PR TITLE
Token finalization to replace imprimitive attribute string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Finalize token to replace imprimitive attribute string ([#169](https://github.com/marp-team/marpit/pull/169))
+
 ## v1.1.0 - 2019-06-03
 
 ### Added

--- a/src/markdown/image/parse.js
+++ b/src/markdown/image/parse.js
@@ -96,6 +96,17 @@ function parseImage(md) {
   let originalURLMap
   let refCount = 0
 
+  const finalizeTokenAttr = token => {
+    // Convert imprimitive attribute value into primitive string
+    if (token.attrs && Array.isArray(token.attrs))
+      token.attrs = token.attrs.map(([name, value]) => [name, value.toString()])
+
+    if (token.type === 'inline') {
+      // Apply finalization recursively to inline tokens
+      for (const t of token.children) finalizeTokenAttr(t)
+    }
+  }
+
   md.core.process = state => {
     const { normalizeLink } = md
 
@@ -116,6 +127,11 @@ function parseImage(md) {
     } finally {
       refCount -= 1
       md.normalizeLink = normalizeLink
+
+      if (refCount === 0) {
+        // Apply finalization for every tokens
+        for (const token of state.tokens) finalizeTokenAttr(token)
+      }
     }
   }
 

--- a/test/markdown/image.js
+++ b/test/markdown/image.js
@@ -5,6 +5,7 @@ import backgroundImage from '../../src/markdown/background_image'
 import comment from '../../src/markdown/comment'
 import inlineSVG from '../../src/markdown/inline_svg'
 import parseDirectives from '../../src/markdown/directives/parse'
+import headerAndFooter from '../../src/markdown/header_and_footer'
 import image from '../../src/markdown/image'
 import slide from '../../src/markdown/slide'
 
@@ -24,6 +25,28 @@ describe('Marpit image plugin', () => {
       .use(inlineSVG)
       .use(image)
       .use(backgroundImage)
+      .use(headerAndFooter)
+
+  describe('Regular image', () => {
+    const [token] = md().parseInline('![](https://example.com/image.jpg)')
+    const [imageToken] = token.children
+
+    it('uses primitive string as src attribute', () =>
+      expect(typeof imageToken.attrGet('src')).toBe('string'))
+
+    context('with header image via directive', () => {
+      const tokens = md().parse(
+        '<!-- header: "![](header.png)" -->\n\n![](content.png)'
+      )
+
+      it('uses primitive string as src attribute for all images', () => {
+        for (const { children } of tokens.filter(t => t.type === 'inline')) {
+          const [t] = children
+          expect(typeof t.attrGet('src')).toBe('string')
+        }
+      })
+    })
+  })
 
   describe('Style for inline image', () => {
     const style = opts => {


### PR DESCRIPTION
To detect Marpit's color shorthand by the value before validation, Marpit v1.1.0 uses imprimitive string created by `new String('foobar')` as an attribute for URL. (#165)

By this change, we found that it has breaking an integration with the markdown-it renderer in Marp for VS Code. (`typeof new String('foobar')` returns `object`, not `string`) [marp-vscode v0.5.0 has fixed a render rule individually.](https://github.com/marp-team/marp-vscode/blob/b65fe996802d22fdd3c0a02eb30590835f54214f/src/extension.ts#L39-L47)

I've added token finalization to replace imprimitive attribute string with primitive value by `toString()`.

markdown-it always expects `string` as the attribute value. Thus, we believe that this finalization would not cause any other integration problems.