### PR TITLE
Allow to define types for theme metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add [`metaType` property for `ThemeSet` class](https://marpit-api.netlify.com/themeset#metaType) to make definable array type for theme metadata ([#170](https://github.com/marp-team/marpit/issues/170), [#171](https://github.com/marp-team/marpit/pull/171))
+- [`ThemeSet#getThemeMeta`](https://marpit-api.netlify.com/themeset#getThemeMeta) to get correct meta value with array support ([#171](https://github.com/marp-team/marpit/pull/171))
+
 ### Fixed
 
 - Finalize token to replace imprimitive attribute string ([#169](https://github.com/marp-team/marpit/pull/169))
+
+### Deprecated
+
+- Dot notation path for meta property in [`ThemeSet#getThemeProp`](https://marpit-api.netlify.com/themeset#getThemeProp) is deprecated in favor of using added `ThemeSet#getThemeMeta` ([#171](https://github.com/marp-team/marpit/pull/171))
 
 ## v1.1.0 - 2019-06-03
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,7 +132,11 @@ declare module '@marp-team/marpit' {
     clear(): void
     delete(name: string): boolean
     get(name: string, fallback?: boolean): Theme | undefined
-    getThemeProp(theme: string | Theme, propPath: string): any
+    getThemeMeta(
+      theme: string | Theme,
+      meta: string
+    ): string | string[] | undefined
+    getThemeProp(theme: string | Theme, prop: string): any
     has(name: string): boolean
     pack(name: string, opts: ThemeSetPackOptions): string
     themes(): IterableIterator<Theme>

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,18 @@ declare module '@marp-team/marpit' {
     ) => { [meta: string]: any }
   }
 
+  type ThemeReservedMeta = {
+    theme: string
+  }
+
+  type ThemeMetaType = {
+    [key: string]: StringConstructor | ArrayConstructor
+  }
+
+  type ThemeOptions = {
+    metaType?: ThemeMetaType
+  }
+
   type ThemeSetPackOptions = {
     after?: string
     before?: string
@@ -54,10 +66,10 @@ declare module '@marp-team/marpit' {
     /** @deprecated A plugin interface for markdown-it is deprecated and will remove in future version. Instead, wrap markdown-it instance when creating Marpit by `new Marpit({ markdown: markdownItInstance })`. */
     readonly markdownItPlugins: (md: any) => void
 
-    protected lastComments?: MarpitRenderResult['comments']
-    protected lastGlobalDirectives?: { [directive: string]: any }
-    protected lastSlideTokens?: any[]
-    protected lastStyles?: string[]
+    protected lastComments: MarpitRenderResult['comments'] | undefined
+    protected lastGlobalDirectives: { [directive: string]: any } | undefined
+    protected lastSlideTokens: any[] | undefined
+    protected lastStyles: string[] | undefined
 
     render(
       markdown: string,
@@ -90,7 +102,7 @@ declare module '@marp-team/marpit' {
   export class Theme {
     protected constructor(name: string, css: string)
 
-    static fromCSS(cssString: string): Theme
+    static fromCSS(cssString: string, opts?: ThemeOptions): Readonly<Theme>
 
     css: string
     height: string
@@ -98,21 +110,19 @@ declare module '@marp-team/marpit' {
       node: any
       value: string
     }[]
-    meta: {
-      theme: string
-      [key: string]: string
-    }
+    meta: Readonly<ThemeReservedMeta & Record<string, string | string[]>>
     name: string
     width: string
 
-    readonly heightPixel?: number
-    readonly widthPixel?: number
+    readonly heightPixel: number | undefined
+    readonly widthPixel: number | undefined
   }
 
   export class ThemeSet {
     constructor()
 
-    default?: Theme
+    default: Theme | undefined
+    metaType: ThemeMetaType
 
     readonly size: number
     private readonly themeMap: Map<string, Theme>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.js'],
   coverageThreshold: { global: { lines: 95 } },
+  restoreMocks: true,
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.js$',
   testURL: 'http://localhost',

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
   "dependencies": {
     "color-string": "^1.5.3",
     "js-yaml": "^3.13.0",
-    "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
     "markdown-it": "^8.4.2",
     "markdown-it-front-matter": "^0.1.2",

--- a/src/postcss/meta.js
+++ b/src/postcss/meta.js
@@ -6,18 +6,34 @@ import postcss from 'postcss'
  *
  * Parse CSS comment written in the format of `@key value`.
  *
+ * @param {Object} [opts]
+ * @param {Object} [opts.metaType] An object for defined types for metadata.
  * @alias module:postcss/meta
  */
-const plugin = postcss.plugin('marpit-postcss-meta', () => (css, ret) => {
-  ret.marpitMeta = ret.marpitMeta || {}
+const plugin = postcss.plugin(
+  'marpit-postcss-meta',
+  (opts = {}) => (css, ret) => {
+    const metaType = opts.metaType || {}
 
-  css.walkComments(comment => {
-    comment.text
-      .slice(0)
-      .replace(/^[*!\s]*@([\w-]+)\s+(.+)$/gim, (_, metaName, value) => {
-        ret.marpitMeta[metaName] = value
-      })
-  })
-})
+    ret.marpitMeta = ret.marpitMeta || {}
+
+    css.walkComments(comment => {
+      comment.text
+        .slice(0)
+        .replace(/^[*!\s]*@([\w-]+)\s+(.+)$/gim, (_, metaName, value) => {
+          if (metaType[metaName] === Array) {
+            // Array meta
+            ret.marpitMeta[metaName] = [
+              ...(ret.marpitMeta[metaName] || []),
+              value,
+            ]
+          } else {
+            // String meta (default)
+            ret.marpitMeta[metaName] = value
+          }
+        })
+    })
+  }
+)
 
 export default plugin

--- a/src/theme.js
+++ b/src/theme.js
@@ -28,6 +28,7 @@ const convertToPixel = value => {
 }
 
 const memoizeProp = name => `${name}Memoized`
+const reservedMetaType = { theme: String }
 
 /**
  * Marpit theme class.
@@ -94,8 +95,10 @@ class Theme {
    * @param {Object} [opts.metaType] An object for defined types for metadata.
    */
   static fromCSS(cssString, opts = {}) {
+    const metaType = { ...(opts.metaType || {}), ...reservedMetaType }
+
     const { css, result } = postcss([
-      postcssMeta(opts),
+      postcssMeta({ metaType }),
       postcssSectionSize,
       postcssImportParse,
     ]).process(cssString)

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -1,5 +1,6 @@
 /** @module */
 import Theme from '../theme'
+import skipThemeValidationSymbol from './symbol'
 
 const css = `
 section {
@@ -43,6 +44,6 @@ h1 {
  * @alias module:theme/scaffold
  * @type {Theme}
  */
-const scaffoldTheme = Theme.fromCSS(css, false)
+const scaffoldTheme = Theme.fromCSS(css, { [skipThemeValidationSymbol]: true })
 
 export default scaffoldTheme

--- a/src/theme/symbol.js
+++ b/src/theme/symbol.js
@@ -1,0 +1,2 @@
+// This symbol is for internal to skip name validation when creating theme.
+export default Symbol('skipThemeValidation')

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -38,9 +38,9 @@ class ThemeSet {
      * The default type settings for theme metadata added by
      * {@link ThemeSet#add}.
      *
-     * A key of object is the name of metadata and a value is type which of
-     * `String` and `Array`. Setting `Array` is useful if theme allowed multiple
-     * definitions in same meta key.
+     * A key of object is the name of metadata and a value is the type which of
+     * `String` and `Array`. You have to set `Array` if the theme allows
+     * multi-time definitions in same meta key.
      *
      * ```css
      * /**

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -62,10 +62,10 @@ class ThemeSet {
      *
      * themeSet.add(css)
      *
-     * console.log(themeSet.getThemeProp('example', 'meta.foo'))
+     * console.log(themeSet.getThemeMeta('example', 'foo'))
      * // => 'allows only one string'
      *
-     * console.log(themeSet.getThemeProp('example', 'meta.bar'))
+     * console.log(themeSet.getThemeMeta('example', 'bar'))
      * // => ['Multiple value 1', 'Multiple value 2', 'Multiple value 3']
      * ```
      *

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -34,6 +34,17 @@ class ThemeSet {
      */
     this.default = undefined
 
+    /**
+     * Type settings for theme metadata.
+     *
+     * A key of object is the name of metadata and a value is type which of
+     * `String` and `Array`. Setting `Array` is useful if theme allowed multiple
+     * definitions in same meta key.
+     *
+     * @type {Object}
+     */
+    this.metaType = {}
+
     Object.defineProperty(this, 'themeMap', { value: new Map() })
   }
 
@@ -55,7 +66,7 @@ class ThemeSet {
    * @throws Will throw an error if the theme name is not specified by `@theme`.
    */
   add(css) {
-    const theme = Theme.fromCSS(css)
+    const theme = Theme.fromCSS(css, { metaType: this.metaType })
 
     this.addTheme(theme)
     return theme
@@ -64,7 +75,7 @@ class ThemeSet {
   /**
    * Add theme instance.
    *
-   * @param {Theme} theme The theme instnace.
+   * @param {Theme} theme The theme instance.
    * @throws Will throw an error if the theme name is not specified.
    */
   addTheme(theme) {

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -91,17 +91,12 @@ class ThemeSet {
    * Add theme CSS from string.
    *
    * @param {string} css The theme CSS string.
-   * @param {Object} [opts]
-   * @param {Object} [opts.metaType] An object for defined types for theme
-   *     metadata. To avoid type mismatch between theme instances, we are NOT
-   *     recommended to specify this option manually. Instead you should use
-   *     [metaType property in ThemeSet instance]{@link ThemeSet#metaType}.
    * @returns {Theme} A created {@link Theme} instance.
    * @throws Will throw an error if the theme name is not specified by `@theme`
    *     metadata.
    */
-  add(css, opts = {}) {
-    const theme = Theme.fromCSS(css, { metaType: this.metaType, ...opts })
+  add(css) {
+    const theme = Theme.fromCSS(css, { metaType: this.metaType })
 
     this.addTheme(theme)
     return theme

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -93,8 +93,9 @@ class ThemeSet {
    * @param {string} css The theme CSS string.
    * @param {Object} [opts]
    * @param {Object} [opts.metaType] An object for defined types for theme
-   *     metadata. By default, ThemeSet uses the value of
-   *     [metaType member in ThemeSet instance]{@link ThemeSet#metaType}.
+   *     metadata. To avoid type mismatch between theme instances, we are NOT
+   *     recommended to specify this option manually. Instead you should use
+   *     [metaType property in ThemeSet instance]{@link ThemeSet#metaType}.
    * @returns {Theme} A created {@link Theme} instance.
    * @throws Will throw an error if the theme name is not specified by `@theme`
    *     metadata.

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -156,7 +156,7 @@ class ThemeSet {
    * default theme specified by the instance is not considered.
    *
    * To support metadata with array type, it will merge into a flatten array
-   * when the all of got valid values are array.
+   * when the all of got valid values that includes imported themes are array.
    *
    * @param {string|Theme} theme The theme name or instance.
    * @param {string} meta The meta name to get.

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -35,11 +35,40 @@ class ThemeSet {
     this.default = undefined
 
     /**
-     * Type settings for theme metadata.
+     * The default type settings for theme metadata added by
+     * {@link ThemeSet#add}.
      *
      * A key of object is the name of metadata and a value is type which of
      * `String` and `Array`. Setting `Array` is useful if theme allowed multiple
      * definitions in same meta key.
+     *
+     * ```css
+     * /**
+     *  * @theme example
+     *  * @foo Single value
+     *  * @foo allows only one string
+     *  * @bar Multiple value 1
+     *  * @bar Multiple value 2
+     *  * @bar Multiple value 3
+     *  * ...
+     * ```
+     *
+     * ```js
+     * const themeSet = new ThemeSet()
+     *
+     * themeSet.metaType = {
+     *   foo: String,
+     *   bar: Array,
+     * }
+     *
+     * themeSet.add(css)
+     *
+     * console.log(themeSet.getThemeProp('example', 'meta.foo'))
+     * // => 'allows only one string'
+     *
+     * console.log(themeSet.getThemeProp('example', 'meta.bar'))
+     * // => ['Multiple value 1', 'Multiple value 2', 'Multiple value 3']
+     * ```
      *
      * @type {Object}
      */
@@ -62,11 +91,16 @@ class ThemeSet {
    * Add theme CSS from string.
    *
    * @param {string} css The theme CSS string.
+   * @param {Object} [opts]
+   * @param {Object} [opts.metaType] An object for defined types for theme
+   *     metadata. By default, ThemeSet uses the value of
+   *     [metaType member in ThemeSet instance]{@link ThemeSet#metaType}.
    * @returns {Theme} A created {@link Theme} instance.
-   * @throws Will throw an error if the theme name is not specified by `@theme`.
+   * @throws Will throw an error if the theme name is not specified by `@theme`
+   *     metadata.
    */
-  add(css) {
-    const theme = Theme.fromCSS(css, { metaType: this.metaType })
+  add(css, opts = {}) {
+    const theme = Theme.fromCSS(css, { metaType: this.metaType, ...opts })
 
     this.addTheme(theme)
     return theme

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -157,14 +157,19 @@ class ThemeSet {
   }
 
   /**
-   * Returns the value of property from a specified theme. It considers
-   * `@import` rules in getting property value.
+   * Returns the value of specified property name or dot notation path from a
+   * theme. It considers `@import` rules in getting value.
    *
    * It will fallback the reference object into the instance's default theme or
-   * scaffold theme when the specified theme is undefined.
+   * scaffold theme when the specified theme is `undefined`.
+   *
+   * It will merge into a flatten array when the all of got valid values are
+   * array. It's useful for metadata with array type.
    *
    * @param {string|Theme} theme The theme name or instance.
-   * @param {string} propPath The property name or path to get.
+   * @param {string} propPath The property name or path to get. It can get the
+   *     value from nested object via dot notation path like `foo.bar`.
+   * @returns {*}
    */
   getThemeProp(theme, propPath, importedThemes = []) {
     let importedProps = []
@@ -191,12 +196,23 @@ class ThemeSet {
         .reverse()
     }
 
-    return [
+    const props = [
       get(themeInstance, propPath),
       ...importedProps,
       get(this.default, propPath),
       get(scaffold, propPath),
-    ].find(t => t)
+    ]
+
+    // Merge array props
+    const filtered = props.filter(p => p)
+
+    if (filtered.length > 0 && filtered.every(p => Array.isArray(p))) {
+      const mergedProps = []
+      for (const prop of filtered.reverse()) mergedProps.push(...prop)
+      return mergedProps
+    }
+
+    return props.find(t => t)
   }
 
   /**

--- a/test/markdown/inline_svg.js
+++ b/test/markdown/inline_svg.js
@@ -2,6 +2,7 @@ import cheerio from 'cheerio'
 import MarkdownIt from 'markdown-it'
 import slide from '../../src/markdown/slide'
 import inlineSVG from '../../src/markdown/inline_svg'
+import skipThemeValidationSymbol from '../../src/theme/symbol'
 import { Theme, ThemeSet } from '../../src/index'
 
 describe('Marpit inline SVG plugin', () => {
@@ -85,7 +86,7 @@ describe('Marpit inline SVG plugin', () => {
       context('with specified default theme', () => {
         const defaultTheme = Theme.fromCSS(
           'section { width: 160px; height: 90px; }',
-          false
+          { [skipThemeValidationSymbol]: true }
         )
 
         const defaultThemeSelector = [

--- a/test/theme.js
+++ b/test/theme.js
@@ -14,6 +14,7 @@ describe('Theme', () => {
       expect(instance.name).toBe('test-theme')
       expect(instance.css).toBe(css)
       expect(instance.meta).toStrictEqual({ theme: 'test-theme' })
+      expect(Object.isFrozen(instance.meta)).toBe(true)
       expect(instance.importRules).toStrictEqual([])
       expect(instance.width).toBeUndefined()
       expect(instance.height).toBeUndefined()
@@ -66,6 +67,43 @@ describe('Theme', () => {
           'yet-another', // @import-theme prepends to the beginning
           'another-theme',
         ]))
+    })
+
+    context('with metaType option argument', () => {
+      it('parses custom metadata with specified type', () => {
+        const instance = Theme.fromCSS(
+          dedent`
+            /**
+             * @theme test
+             * @string A
+             * @string B
+             * @array A
+             * @array B
+             * @unknown A
+             * @unknown B
+             */
+          `,
+          { metaType: { string: String, array: Array } }
+        )
+
+        expect(instance.meta.string).toBe('B')
+        expect(instance.meta.array).toStrictEqual(['A', 'B'])
+        expect(instance.meta.unknown).toBe('B')
+      })
+
+      it('cannot override the type for restricted metadata', () => {
+        const instance = Theme.fromCSS(
+          dedent`
+            /**
+             * @theme A
+             * @theme B
+             */
+          `,
+          { metaType: { theme: Array } }
+        )
+
+        expect(instance.meta.theme).toStrictEqual('B')
+      })
     })
   })
 

--- a/test/theme.js
+++ b/test/theme.js
@@ -1,4 +1,5 @@
 import dedent from 'dedent'
+import skipThemeValidationSymbol from '../src/theme/symbol'
 import { Theme } from '../src/index'
 
 describe('Theme', () => {
@@ -26,11 +27,11 @@ describe('Theme', () => {
           'Marpit theme CSS requires @theme meta.'
         ))
 
-      context('with validate option as false (for internal)', () => {
+      context('with specified internal symbol for skipping validation', () => {
         it('returns theme instance without name', () => {
           let instance
           expect(() => {
-            instance = Theme.fromCSS(css, false)
+            instance = Theme.fromCSS(css, { [skipThemeValidationSymbol]: true })
           }).not.toThrow()
 
           expect(instance.name).toBeUndefined()
@@ -70,7 +71,9 @@ describe('Theme', () => {
 
   describe('widthPixel property', () => {
     const instance = width =>
-      Theme.fromCSS(`section { width: ${width}; }`, false)
+      Theme.fromCSS(`section { width: ${width}; }`, {
+        [skipThemeValidationSymbol]: true,
+      })
 
     it('returns a width pixel as number', () =>
       expect(instance('1280px').widthPixel).toBe(1280))
@@ -103,7 +106,9 @@ describe('Theme', () => {
 
   describe('heightPixel property', () => {
     const instance = height =>
-      Theme.fromCSS(`section { height: ${height}; }`, false)
+      Theme.fromCSS(`section { height: ${height}; }`, {
+        [skipThemeValidationSymbol]: true,
+      })
 
     it('returns a width pixel as number', () =>
       expect(instance('960px').heightPixel).toBe(960))

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -269,13 +269,13 @@ describe('ThemeSet', () => {
       it('fallbacks to scaffold value when prop in default theme is not defined', () =>
         expect(getThemeProp('not-contained', 'height')).toBe(height))
 
-      context('with array meta', () => {
+      context('[Deprecated fallback] with array meta', () => {
         beforeEach(() => {
           instance.default = arrayMetaTheme
         })
 
         it('does not fallback array value to default theme', () =>
-          expect(getThemeProp('not-contained', 'meta.array')).toStrictEqual([]))
+          expect(getThemeProp('not-contained', 'meta.array')).toBeUndefined())
 
         it('returns correct array when specified default theme', () =>
           expect(getThemeProp('array-meta', 'meta.array')).toStrictEqual([
@@ -304,7 +304,7 @@ describe('ThemeSet', () => {
         expect(getThemeProp('undefined-theme', 'width')).toBe(width))
     })
 
-    context('with path to nested meta property', () => {
+    context('[Deprecated fallback] with path to nested meta property', () => {
       it('returns the value of property', () => {
         expect(getThemeProp('meta', 'meta.meta-value')).toBe('A')
         expect(getThemeProp('meta', 'meta.unknown')).toBeUndefined()
@@ -317,25 +317,28 @@ describe('ThemeSet', () => {
       })
     })
 
-    context('with path to array meta and @import rules', () => {
-      it('returns merged array defined in all themes', () => {
-        expect(getThemeProp('array-meta-imported', 'meta.array')).toStrictEqual(
-          ['A', 'B', 'C']
-        )
-        expect(
-          getThemeProp('array-meta-double-imported', 'meta.array')
-        ).toStrictEqual(['A', 'B', 'C', 'D'])
-      })
+    context(
+      '[Deprecated fallback] with path to array meta and @import rules',
+      () => {
+        it('returns merged array defined in all themes', () => {
+          expect(
+            getThemeProp('array-meta-imported', 'meta.array')
+          ).toStrictEqual(['A', 'B', 'C'])
+          expect(
+            getThemeProp('array-meta-double-imported', 'meta.array')
+          ).toStrictEqual(['A', 'B', 'C', 'D'])
+        })
 
-      it('returns meta value in a primary theme when have mixed meta types', () => {
-        expect(
-          getThemeProp('array-meta-override-by-string', 'meta.array')
-        ).toBe('str')
-        expect(
-          getThemeProp('string-meta-override-by-array', 'meta.meta-value')
-        ).toStrictEqual(['B', 'C'])
-      })
-    })
+        it('returns meta value in a primary theme when have mixed meta types', () => {
+          expect(
+            getThemeProp('array-meta-override-by-string', 'meta.array')
+          ).toBe('str')
+          expect(
+            getThemeProp('string-meta-override-by-array', 'meta.meta-value')
+          ).toStrictEqual(['B', 'C'])
+        })
+      }
+    )
   })
 
   describe('#has', () => {

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -3,22 +3,22 @@ import scaffoldTheme from '../src/theme/scaffold'
 import { ThemeSet, Theme } from '../src/index'
 
 describe('ThemeSet', () => {
-  const instance = new ThemeSet()
+  let instance
 
   beforeEach(() => {
-    instance.default = undefined
-    instance.clear()
+    instance = new ThemeSet()
   })
 
   describe('#constructor', () => {
-    const bareInstance = new ThemeSet()
+    it('has default theme property as undefined', () =>
+      expect(instance.default).toBeUndefined())
 
-    it('has default property as undefined', () =>
-      expect(bareInstance.default).toBeUndefined())
+    it('has default metaType property as an empty object', () =>
+      expect(instance.metaType).toStrictEqual({}))
 
     it('has unenumerable themeMap property', () => {
-      expect(bareInstance.themeMap).toBeInstanceOf(Map)
-      expect({}.propertyIsEnumerable.call(bareInstance, 'themeMap')).toBe(false)
+      expect(instance.themeMap).toBeInstanceOf(Map)
+      expect({}.propertyIsEnumerable.call(instance, 'themeMap')).toBe(false)
     })
   })
 
@@ -33,6 +33,12 @@ describe('ThemeSet', () => {
   })
 
   describe('#add', () => {
+    let spy
+
+    beforeEach(() => {
+      spy = jest.spyOn(Theme, 'fromCSS')
+    })
+
     it('adds theme and returns parsed Theme instance', () => {
       expect(instance.add('/* @theme test-theme */')).toBeInstanceOf(Theme)
       expect(instance.has('test-theme')).toBe(true)
@@ -43,6 +49,31 @@ describe('ThemeSet', () => {
 
     it('throws error when CSS has not @theme meta', () =>
       expect(() => instance.add('h1 { color: #f00; }')).toThrow())
+
+    it('passes an empty metaType option to Theme.fromCSS', () => {
+      instance.add('/* @theme a */')
+      expect(spy).toBeCalledWith('/* @theme a */', { metaType: {} })
+    })
+
+    context('with metaType option argument', () => {
+      const metaType = { array: Array }
+
+      it('passes custom metaType option to Theme.fromCSS', () => {
+        instance.add('/* @theme b */', { metaType })
+        expect(spy).toBeCalledWith('/* @theme b */', { metaType })
+      })
+    })
+
+    context("when ThemeSet's metaType property has changed", () => {
+      const metaType = { array: Array }
+
+      it('passes changed metaType option to Theme.fromCSS by default', () => {
+        instance.metaType = metaType
+        instance.add('/* @theme c */')
+
+        expect(spy).toBeCalledWith('/* @theme c */', { metaType })
+      })
+    })
   })
 
   describe('#addTheme', () => {

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -274,19 +274,14 @@ describe('ThemeSet', () => {
           instance.default = arrayMetaTheme
         })
 
-        it('fallbacks array to default theme when specified theme is not contained', () => {
-          expect(getThemeProp('not-contained', 'meta.array')).toStrictEqual([
-            'A',
-            'B',
-          ])
-        })
+        it('does not fallback array value to default theme', () =>
+          expect(getThemeProp('not-contained', 'meta.array')).toStrictEqual([]))
 
-        it('returns correct array even if specified default theme', () => {
+        it('returns correct array when specified default theme', () =>
           expect(getThemeProp('array-meta', 'meta.array')).toStrictEqual([
             'A',
             'B',
-          ])
-        })
+          ]))
       })
     })
 

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -55,15 +55,6 @@ describe('ThemeSet', () => {
       expect(spy).toBeCalledWith('/* @theme a */', { metaType: {} })
     })
 
-    context('with metaType option argument', () => {
-      const metaType = { array: Array }
-
-      it('passes custom metaType option to Theme.fromCSS', () => {
-        instance.add('/* @theme b */', { metaType })
-        expect(spy).toBeCalledWith('/* @theme b */', { metaType })
-      })
-    })
-
     context("when ThemeSet's metaType property has changed", () => {
       const metaType = { array: Array }
 
@@ -194,23 +185,32 @@ describe('ThemeSet', () => {
       )
 
       // Array meta
-      instance.add('/* @theme array-meta */\n/* @array A */\n/* @array B */', {
-        metaType: { array: Array },
-      })
-      instance.add(
-        '/* @theme array-meta-imported */\n/* @array C */\n@import "array-meta";',
-        { metaType: { array: Array } }
+      instance.addTheme(
+        Theme.fromCSS(
+          '/* @theme array-meta */\n/* @array A */\n/* @array B */',
+          { metaType: { array: Array } }
+        )
       )
-      instance.add(
-        '/* @theme array-meta-double-imported */\n/* @array D */\n@import "array-meta-imported";',
-        { metaType: { array: Array } }
+      instance.addTheme(
+        Theme.fromCSS(
+          '/* @theme array-meta-imported */\n/* @array C */\n@import "array-meta";',
+          { metaType: { array: Array } }
+        )
+      )
+      instance.addTheme(
+        Theme.fromCSS(
+          '/* @theme array-meta-double-imported */\n/* @array D */\n@import "array-meta-imported";',
+          { metaType: { array: Array } }
+        )
       )
       instance.add(
         '/* @theme array-meta-override-by-string */\n/* @array str */\n@import "array-meta";'
       )
-      instance.add(
-        '/* @theme string-meta-override-by-array */\n/* @meta-value B */\n/* @meta-value C */\n@import "meta";',
-        { metaType: { 'meta-value': Array } }
+      instance.addTheme(
+        Theme.fromCSS(
+          '/* @theme string-meta-override-by-array */\n/* @meta-value B */\n/* @meta-value C */\n@import "meta";',
+          { metaType: { 'meta-value': Array } }
+        )
       )
     })
 

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -150,10 +150,15 @@ describe('ThemeSet', () => {
   })
 
   describe('#getThemeProp', () => {
+    let arrayMetaTheme
     let fallbackTheme
     let sizeSpecifiedTheme
 
     beforeEach(() => {
+      arrayMetaTheme = Theme.fromCSS(
+        '/* @theme array-meta */\n/* @array A */\n/* @array B */',
+        { metaType: { array: Array } }
+      )
       fallbackTheme = instance.add('/* @theme fallback */')
       sizeSpecifiedTheme = instance.add(dedent`
         /* @theme size-specified */
@@ -185,12 +190,7 @@ describe('ThemeSet', () => {
       )
 
       // Array meta
-      instance.addTheme(
-        Theme.fromCSS(
-          '/* @theme array-meta */\n/* @array A */\n/* @array B */',
-          { metaType: { array: Array } }
-        )
-      )
+      instance.addTheme(arrayMetaTheme)
       instance.addTheme(
         Theme.fromCSS(
           '/* @theme array-meta-imported */\n/* @array C */\n@import "array-meta";',
@@ -268,6 +268,26 @@ describe('ThemeSet', () => {
 
       it('fallbacks to scaffold value when prop in default theme is not defined', () =>
         expect(getThemeProp('not-contained', 'height')).toBe(height))
+
+      context('with array meta', () => {
+        beforeEach(() => {
+          instance.default = arrayMetaTheme
+        })
+
+        it('fallbacks array to default theme when specified theme is not contained', () => {
+          expect(getThemeProp('not-contained', 'meta.array')).toStrictEqual([
+            'A',
+            'B',
+          ])
+        })
+
+        it('returns correct array even if specified default theme', () => {
+          expect(getThemeProp('array-meta', 'meta.array')).toStrictEqual([
+            'A',
+            'B',
+          ])
+        })
+      })
     })
 
     context('with @import rules', () => {

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -202,6 +202,10 @@ describe('ThemeSet', () => {
         { metaType: { array: Array } }
       )
       instance.add(
+        '/* @theme array-meta-double-imported */\n/* @array D */\n@import "array-meta-imported";',
+        { metaType: { array: Array } }
+      )
+      instance.add(
         '/* @theme array-meta-override-by-string */\n/* @array str */\n@import "array-meta";'
       )
       instance.add(
@@ -303,6 +307,9 @@ describe('ThemeSet', () => {
         expect(getThemeProp('array-meta-imported', 'meta.array')).toStrictEqual(
           ['A', 'B', 'C']
         )
+        expect(
+          getThemeProp('array-meta-double-imported', 'meta.array')
+        ).toStrictEqual(['A', 'B', 'C', 'D'])
       })
 
       it('returns meta value in a primary theme when have mixed meta types', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4673,11 +4673,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.isfinite@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"


### PR DESCRIPTION
Now `Theme#fromCSS` allows second option argument to specify `metaType` to parse metadata with type definition. And `ThemeSet` instance has `metaType` property to set type definition for theme metadata. It would pass to `Theme#fromCSS` when calling `ThemeSet#add`.

~~We also have improved `ThemeSet#getThemeProp`. It will merge into a flatten array when the all of got valid values are array. It can deal with array meta values correctly, included imported meta by `@import` and `@import-theme`.~~

**UPDATE:** It has incorrect over-fallback to the default theme specified by `ThemeSet.default`. Theme metadata have to take care only of imported CSS. We should make a new `#getThemeMeta` method to get support for array meta.

```css
/**
 * @theme example
 * @foo Single value
 * @foo allows only one string
 * @bar Multiple value 1
 * @bar Multiple value 2
 * @bar Multiple value 3
 * ...
```

```js
const themeSet = new ThemeSet()

themeSet.metaType = {
  foo: String,
  bar: Array,
}

themeSet.add(css)

console.log(themeSet.getThemeMeta('example', 'foo'))
// => 'allows only one string'

console.log(themeSet.getThemeMeta('example', 'bar'))
// => ['Multiple value 1', 'Multiple value 2', 'Multiple value 3']
```

Resolves #170.

> To tell the truth, `Theme#fromCSS` already had allowed boolean value as second argument to ignore validation. This uses to initialize Marpit's scaffold theme, but it must not be accessible easily because it's just an internal. So we have changed to use `skipThemeValidation` symbol for this usage.