### PR TITLE
Allow loose YAML parsing for custom directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow loose YAML parsing for custom directives ([#173](https://github.com/marp-team/marpit/pull/173))
+
 ## v1.2.0 - 2019-06-17
 
 ### Added

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -32,7 +32,15 @@ function parse(md, opts = {}) {
     md.use(MarkdownItFrontMatter, fm => {
       frontMatterObject.text = fm
 
-      const parsed = yaml(fm, !!md.marpit.options.looseYAML)
+      const parsed = yaml(
+        fm,
+        marpit.options.looseYAML
+          ? [
+              ...Object.keys(marpit.customDirectives.global),
+              ...Object.keys(marpit.customDirectives.local),
+            ]
+          : false
+      )
       if (parsed !== false) frontMatterObject.yaml = parsed
     })
   }

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -46,7 +46,8 @@ class Marpit {
    *     slide page at before of headings. it would apply to headings whose
    *     larger than or equal to the specified level if a number is given, or
    *     ONLY specified levels if a number array.
-   * @param {boolean} [opts.looseYAML=false] Allow loose YAML for directives.
+   * @param {boolean} [opts.looseYAML=false] Allow loose YAML parsing in
+   *     built-in directives, and custom directives defined in current instance.
    * @param {MarkdownIt|string|Object|Array} [opts.markdown] An instance of
    *     markdown-it or its constructor option(s) for wrapping. Marpit will
    *     create its instance based on CommonMark when omitted.

--- a/test/markdown/directives/yaml.js
+++ b/test/markdown/directives/yaml.js
@@ -2,14 +2,14 @@ import dedent from 'dedent'
 import yaml from '../../../src/markdown/directives/yaml'
 
 describe('Marpit directives YAML parser', () => {
-  it("ignores directive's special char with false allowLoose option", () =>
+  it("ignores directive's special char with false looseDirectives option", () =>
     expect(yaml('color: #f00', false).color).toBeNull())
 
-  context('with allowLoose option as true', () => {
+  context('with looseDirectives option as true', () => {
     it("parses directive's special char as string", () =>
       expect(yaml('color: #f00', true).color).toBe('#f00'))
 
-    it('disallows loose parsing in not defined directives', () => {
+    it('disallows loose parsing in not built-in directives', () => {
       const body = dedent`
         backgroundColor: #f00
         header: _"HELLO!"_
@@ -48,6 +48,23 @@ describe('Marpit directives YAML parser', () => {
         class: &anchored klass
         _class: *anchored
       `)
+    })
+  })
+
+  context('with looseDirectives option as extra keys', () => {
+    it('allows loose parsing in not built-in directives', () => {
+      const body = dedent`
+        notDefinedDirective: # THIS IS NOT A COMMENT
+        a.c: #def
+        abc: # THIS IS A COMMENT
+      `
+      const parsed = yaml(body, ['notDefinedDirective', 'a.c'])
+
+      expect(parsed.notDefinedDirective).toBe('# THIS IS NOT A COMMENT')
+      expect(parsed['a.c']).toBe('#def')
+
+      // It would fail if you forget escape special characters for RegEx
+      expect(parsed.abc).toBeNull()
     })
   })
 })

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -102,6 +102,30 @@ describe('Marpit', () => {
         expect(first.meta.marpitDirectives).toStrictEqual({ test: 'local' })
         expect(second.meta.marpitDirectives).toStrictEqual({ test: 'spot' })
       })
+
+      context('with looseYAML option as true', () => {
+        it('allows loose YAML parsing for custom directives', () => {
+          const marpit = new Marpit({ container: undefined, looseYAML: true })
+          marpit.customDirectives.global.a = v => ({ a: v })
+          marpit.customDirectives.local.b = v => ({ b: v })
+
+          const [token] = marpit.markdown.parse('---\na: #123\nb: #abc\n---')
+          expect(token.meta.marpitDirectives.a).toBe('#123')
+          expect(token.meta.marpitDirectives.b).toBe('#abc')
+        })
+      })
+
+      context('with looseYAML option as false', () => {
+        it('disallows loose YAML parsing for custom directives', () => {
+          const marpit = new Marpit({ container: undefined, looseYAML: false })
+          marpit.customDirectives.global.a = v => ({ a: v })
+          marpit.customDirectives.local.b = v => ({ b: v })
+
+          const [token] = marpit.markdown.parse('---\na: #123\nb: #abc\n---')
+          expect(token.meta.marpitDirectives.a).toBeNull()
+          expect(token.meta.marpitDirectives.b).toBeNull()
+        })
+      })
     })
 
     it('has themeSet property', () => {
@@ -335,7 +359,7 @@ describe('Marpit', () => {
         ---
       `
 
-      it('allows loose YAML parsing when looseYAML is true', () => {
+      it('allows loose YAML parsing for built-in directives when looseYAML is true', () => {
         const rendered = instance(true).render(markdown)
         const $ = cheerio.load(rendered.html)
         const firstStyle = $('section:nth-of-type(1)').attr('style')
@@ -347,7 +371,7 @@ describe('Marpit', () => {
         expect(secondStyle).not.toContain('color:')
       })
 
-      it('disallows loose YAML parsing when looseYAML is false', () => {
+      it('disallows loose YAML parsing for built-in directives when looseYAML is false', () => {
         const rendered = instance(false).render(markdown)
         const $ = cheerio.load(rendered.html)
         const style = $('section:nth-of-type(1)').attr('style')


### PR DESCRIPTION
When `looseYAML` option is enabled, loose parsing had enabled only in built-in directives. For making consistent of parsing Marpit directives,  it should be allowed loose parsing also in custom directives defined in current instance.