### PR TITLE
Upgrade markdown-it to v9 for following the latest CommonMark spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Follow the latest spec of [CommonMark 0.29](https://spec.commonmark.org/0.29/) by upgraded markdown-it v9 ([#174](https://github.com/marp-team/marpit/pull/174))
 - Allow customization the content of pagination ([#175](https://github.com/marp-team/marpit/pull/175))
 
 ## v1.2.0 - 2019-06-17

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -18,7 +18,7 @@ foo
 bar
 ```
 
-?> An empty line may be required before the dash ruler by the spec of [CommonMark](https://spec.commonmark.org/0.28/#example-28). You can use the underline ruler `___`, asterisk ruler `***`, and space-included ruler `- - -` when you not want to add empty lines.
+?> An empty line may be required before the dash ruler by the spec of [CommonMark](https://spec.commonmark.org/0.29/#example-28). You can use the underline ruler `___`, asterisk ruler `***`, and space-included ruler `- - -` when you not want to add empty lines.
 
 ## Extended features
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "color-string": "^1.5.3",
     "js-yaml": "^3.13.0",
     "lodash.kebabcase": "^4.1.1",
-    "markdown-it": "^8.4.2",
+    "markdown-it": "^9.0.0",
     "markdown-it-front-matter": "^0.1.2",
     "postcss": "^7.0.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4822,6 +4822,17 @@ markdown-it@^8.4.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+markdown-it@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-9.0.0.tgz#804e9285d2a0e2457216ed6a1d96e219483f2fb1"
+  integrity sha512-bUVTYGt/K/mYr3HlE+PBe6TOTyWghcpSZqOD9t+NFRlwJMhp9Kp6WQ8fJ26I6v1Xo71UmPYt1S4Hc9Lq8GZx2Q==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-table@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"


### PR DESCRIPTION
This PR bumps major version of markdown-it to follow the latest CommonMark spec (0.29). 

It has no breaking of plugin system, so we would be able to upgrade markdown-it safely.