### PR TITLE
Remove deprecated dot notation support for meta in ThemeSet#getThemeProp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Allow customization the content of pagination ([#175](https://github.com/marp-team/marpit/pull/175))
 - Upgrade dependent packages to the latest version ([#176](https://github.com/marp-team/marpit/pull/176))
 
+### Removed
+
+- Remove deprecated dot notation support for meta in `ThemeSet#getThemeProp` ([#177](https://github.com/marp-team/marpit/pull/177))
+
 ## v1.2.0 - 2019-06-17
 
 ### Added

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -193,14 +193,6 @@ class ThemeSet {
    * @returns {*}
    */
   getThemeProp(theme, prop) {
-    // TODO: Remove deprecated dot notation support for meta
-    if (prop.startsWith('meta.')) {
-      console.warn(
-        'Deprecation warning: Dot notation path in getThemeProp to get meta value has no longer supported. We still have a special fallback into getThemeMeta method, but it would remove soon.'
-      )
-      return this.getThemeMeta(theme, prop.slice(5))
-    }
-
     const themeInstance = theme instanceof Theme ? theme : this.get(theme)
     const props = themeInstance
       ? this.resolveImport(themeInstance).map(t => t[prop])

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -353,15 +353,6 @@ describe('ThemeSet', () => {
       it('ignores importing undefined theme and fallbacks to scaffold value', () =>
         expect(getThemeProp('undefined-theme', 'width')).toBe(width))
     })
-
-    context('[Deprecated] with dot notation path to meta property', () => {
-      it('returns the value of property by using #getThemeMeta', () => {
-        const spy = jest.spyOn(instance, 'getThemeMeta')
-
-        expect(getThemeProp('meta', 'meta.meta-value')).toBe('A')
-        expect(spy).toBeCalledWith('meta', 'meta-value')
-      })
-    })
   })
 
   describe('#has', () => {


### PR DESCRIPTION
ref. https://github.com/marp-team/marpit/pull/171#discussion_r294146545
