### PR TITLE
Override display declaration of <section> for advanced background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Override declaration of `<section>` for advanced background to `display: block` ([#185](https://github.com/marp-team/marpit/pull/185))
+
 ## v1.3.1 - 2019-08-11
 
 ### Added

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -14,6 +14,7 @@ const plugin = postcss.plugin(
     css.last.after(
       `
 section[data-marpit-advanced-background="background"] {
+  display: block !important;
   padding: 0 !important;
 }
 


### PR DESCRIPTION
This PR will override `display` declaration of `<section>` for advanced background.

When the `<section>` container is using CSS grid (`display: grid`), the rendering of the advanced background container inherited from `<section>` will be confined in a top-left grid. So Marpit have to prevent overriding `display` declaration of the background container from theme CSS.