### PR TITLE
Update CircleCI configuration to use v2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ executors:
     docker:
       - image: circleci/node:<< parameters.version >>
     working_directory: ~/marpit
-    environment:
-      YARN_VERSION: 1.17.3
 
 commands:
   install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,18 @@
-references:
-  base: &base
+version: 2.1
+
+executors:
+  node:
+    parameters:
+      version:
+        type: string
     docker:
-      - image: circleci/node:10.16.0
+      - image: circleci/node:<< parameters.version >>
     working_directory: ~/marpit
+    environment:
+      YARN_VERSION: 1.17.3
+
+commands:
+  test:
     steps:
       - run: node --version
 
@@ -11,26 +21,24 @@ references:
           name: Upgrade yarn
           command: |
             sudo -E sh -c 'curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-                           && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-                           && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-                           && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-                           && rm yarn-v$YARN_VERSION.tar.gz'
-          environment:
-            YARN_VERSION: 1.16.0
+              && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+              && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+              && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+              && rm yarn-v$YARN_VERSION.tar.gz'
 
       - checkout
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
-            - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
-            - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-
+            - v2.1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+            - v2.1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
+            - v2.1-dependencies-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install
       - run: yarn audit
 
       - save_cache:
-          key: v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+          key: v2.1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
           paths:
             - node_modules
             - ~/.cache/yarn
@@ -62,40 +70,24 @@ references:
           path: ./coverage
           destination: coverage
 
-version: 2
 jobs:
-  current:
-    <<: *base
-
-  carbon:
-    <<: *base
-    docker:
-      - image: circleci/node:carbon
-
-  erbium:
-    <<: *base
-    docker:
-      - image: circleci/node:12
-
-  github-release:
-    <<: *base
+  node8:
+    executor:
+      name: node
+      version: 8
     steps:
-      - checkout
-      - run:
-          name: Create release on GitHub
-          command: curl https://raw.githubusercontent.com/marp-team/marp/master/github-release.js | node
+      - test
 
-workflows:
-  version: 2
-  build:
-    jobs:
-      - current
-      - carbon
-      - erbium
-      - github-release:
-          context: github-release
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+  node10:
+    executor:
+      name: node
+      version: 10.16.0 # Specify TLS version for development
+    steps:
+      - test
+
+  node12:
+    executor:
+      name: node
+      version: 12
+    steps:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ executors:
     parameters:
       version:
         type: string
+        default: lts
     docker:
       - image: circleci/node:<< parameters.version >>
     working_directory: ~/marpit
@@ -12,10 +13,15 @@ executors:
       YARN_VERSION: 1.17.3
 
 commands:
-  test:
+  install:
+    parameters:
+      postinstall:
+        type: steps
+        default: []
+      yarn:
+        type: string
+        default: 1.17.3
     steps:
-      - run: node --version
-
       # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#upgradingdowngrading-yarn
       - run:
           name: Upgrade yarn
@@ -25,8 +31,8 @@ commands:
               && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
               && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
               && rm yarn-v$YARN_VERSION.tar.gz'
-
-      - checkout
+          environment:
+            YARN_VERSION: << parameters.yarn >>
 
       - restore_cache:
           keys:
@@ -35,13 +41,27 @@ commands:
             - v2.1-dependencies-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install
-      - run: yarn audit
+      - steps: << parameters.postinstall >>
 
       - save_cache:
           key: v2.1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
           paths:
             - node_modules
             - ~/.cache/yarn
+
+  audit:
+    steps:
+      - checkout
+      - install:
+          postinstall:
+            - run: yarn audit
+
+  test:
+    steps:
+      - run: node --version
+
+      - checkout
+      - install
 
       - run:
           name: Prettier formatting
@@ -71,23 +91,42 @@ commands:
           destination: coverage
 
 jobs:
-  node8:
+  audit:
+    executor: node
+    steps:
+      - audit
+
+  test-node8:
     executor:
       name: node
-      version: 8
+      version: '8'
     steps:
       - test
 
-  node10:
+  test-node10:
     executor:
       name: node
-      version: 10.16.0 # Specify TLS version for development
+      version: '10.16.0' # Specify TLS version for development
     steps:
       - test
 
-  node12:
+  test-node12:
     executor:
       name: node
-      version: 12
+      version: '12'
     steps:
       - test
+
+workflows:
+  test:
+    jobs:
+      - audit
+      - test-node8:
+          requires:
+            - audit
+      - test-node10:
+          requires:
+            - audit
+      - test-node12:
+          requires:
+            - audit

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,4 +1,4 @@
-name: GitHub release
+name: GitHub Release
 
 on:
   push:
@@ -10,16 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js
-        uses: actions/setup-node@v1
+      - uses: marp-team/actions@v1
         with:
-          node-version: '10.x'
-      - name: Create release on GitHub
-        run: |
-          wget https://raw.githubusercontent.com/marp-team/marp/master/github-release.js
-          export TAG=${GITHUB_REF:10}
-          export USER=${GITHUB_REPOSITORY%%/*}
-          export REPO=${GITHUB_REPOSITORY##*/}
-          node github-release.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          task: release
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,25 @@
+name: GitHub release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Create release on GitHub
+        run: |
+          wget https://raw.githubusercontent.com/marp-team/marp/master/github-release.js
+          export TAG=${GITHUB_REF:10}
+          export USER=${GITHUB_REPOSITORY%%/*}
+          export REPO=${GITHUB_REPOSITORY##*/}
+          node github-release.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update CircleCI configuration to use v2.1 ([#187](https://github.com/marp-team/marpit/pull/187))
+
 ## v1.3.2 - 2019-08-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "preversion": "npm-run-all --npm-path yarn --parallel check-audit format:check lint:* test:coverage",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "version": "curl https://raw.githubusercontent.com/marp-team/marp/master/version.js | node && git add -A CHANGELOG.md",
+    "version": "curl https://raw.githubusercontent.com/marp-team/actions/v1/lib/scripts/version.js | node && git add -A CHANGELOG.md",
     "watch": "babel src --out-dir lib -w --verbose"
   },
   "devDependencies": {


### PR DESCRIPTION
Marpit's CircleCI will run on v2.1. A new configuration has some maintainable commands (`install`, `test`, `audit`).

### Notable changes

- As same as Marp CLI, we check `yarn audit` first before running test jobs.
- Update scripts of version and GitHub Release have moved to GitHub Actions provided by [@marp-team/actions](https://github.com/marp-team/actions).