### PR TITLE
Remove dollar prefix alias for global directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Update CircleCI configuration to use v2.1 ([#187](https://github.com/marp-team/marpit/pull/187))
 
+### Removed
+
+- Deprecated dollar prefix alias for global directive ([#182](https://github.com/marp-team/marpit/issues/182), [#189](https://github.com/marp-team/marpit/pull/189))
+
 ## v1.3.2 - 2019-08-23
 
 ### Fixed

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -76,31 +76,18 @@ function parse(md, opts = {}) {
       let recognized = false
 
       for (const key of Object.keys(obj)) {
-        const globalKey = key.startsWith('$')
-          ? (() => {
-              if (marpit.customDirectives.global[key]) return key
-
-              console.warn(
-                `Deprecation warning: Dollar prefix support for global directive "${key}" is deprecated and will remove soon. Just remove "$" from "${key}" to fix ("${key.slice(
-                  1
-                )}").`
-              )
-              return key.slice(1)
-            })()
-          : key
-
-        if (directives.globals[globalKey]) {
+        if (directives.globals[key]) {
           recognized = true
           globalDirectives = {
             ...globalDirectives,
-            ...directives.globals[globalKey](obj[key], marpit),
+            ...directives.globals[key](obj[key], marpit),
           }
-        } else if (marpit.customDirectives.global[globalKey]) {
+        } else if (marpit.customDirectives.global[key]) {
           recognized = true
           globalDirectives = {
             ...globalDirectives,
             ...applyBuiltinDirectives(
-              marpit.customDirectives.global[globalKey](obj[key], marpit),
+              marpit.customDirectives.global[key](obj[key], marpit),
               directives.globals
             ),
           }

--- a/test/markdown/directives/parse.js
+++ b/test/markdown/directives/parse.js
@@ -72,10 +72,13 @@ describe('Marpit directives parse plugin', () => {
 
       it('applies meta to all slides', () => {
         const parsed = md().parse(text)
-        parsed.forEach(t => {
-          if (t.type === 'marpit_slide_open')
-            expect(t.meta.marpitDirectives).toStrictEqual(expected)
-        })
+        const slides = parsed.filter(t => t.type === 'marpit_slide_open')
+
+        expect.assertions(slides.length)
+
+        for (const { meta } of slides) {
+          expect(meta.marpitDirectives).toStrictEqual(expected)
+        }
       })
 
       it('applies global directives to Marpit instance', () => {
@@ -84,11 +87,6 @@ describe('Marpit directives parse plugin', () => {
 
         md().parse('<!-- class: test -->')
         expect(marpitStub.lastGlobalDirectives).toStrictEqual({})
-      })
-
-      it('allows global directive name prefixed "$" [DEPRECATED]', () => {
-        md().parse('<!-- $theme: test_theme -->')
-        expect(marpitStub.lastGlobalDirectives).toStrictEqual(expected)
       })
 
       it('marks directive comments as parsed', () => {


### PR DESCRIPTION
Resolves #182. `$` prefix has already deprecated in [v1.3.1](https://github.com/marp-team/marpit/releases/tag/v1.3.1).

We are already working about the escape hatch for GUI tool  users at marp-team/marp-core#104.