### PR TITLE
Mark well-known magic comments in linter and formatter as parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Ignore well-known magic comments in collected comments ([#191](https://github.com/marp-team/marpit/issues/191), [#199](https://github.com/marp-team/marpit/pull/199))
 - Upgrade dependent packages to the latest version ([#196](https://github.com/marp-team/marpit/pull/196))
 
 ## v1.4.0 - 2019-09-12

--- a/src/markdown/directives/parse.js
+++ b/src/markdown/directives/parse.js
@@ -2,15 +2,11 @@
 import MarkdownItFrontMatter from 'markdown-it-front-matter'
 import yaml from './yaml'
 import * as directives from './directives'
+import { markAsParsed } from '../comment'
 import marpitPlugin from '../marpit_plugin'
 
-const isComment = token =>
+const isDirectiveComment = token =>
   token.type === 'marpit_comment' && token.meta.marpitParsedDirectives
-
-const markAsParsed = token => {
-  token.meta = token.meta || {}
-  token.meta.marpitCommentParsed = 'directive'
-}
 
 /**
  * Parse Marpit directives and store result to the slide token meta.
@@ -101,14 +97,17 @@ function parse(md, opts = {}) {
 
     for (const token of state.tokens) {
       if (
-        isComment(token) &&
+        isDirectiveComment(token) &&
         applyDirectives(token.meta.marpitParsedDirectives)
       ) {
-        markAsParsed(token)
+        markAsParsed(token, 'directive')
       } else if (token.type === 'inline') {
         for (const t of token.children) {
-          if (isComment(t) && applyDirectives(t.meta.marpitParsedDirectives))
-            markAsParsed(t)
+          if (
+            isDirectiveComment(t) &&
+            applyDirectives(t.meta.marpitParsedDirectives)
+          )
+            markAsParsed(t, 'directive')
         }
       }
     }
@@ -190,14 +189,17 @@ function parse(md, opts = {}) {
 
         cursor.spot = {}
       } else if (
-        isComment(token) &&
+        isDirectiveComment(token) &&
         applyDirectives(token.meta.marpitParsedDirectives)
       ) {
-        markAsParsed(token)
+        markAsParsed(token, 'directive')
       } else if (token.type === 'inline') {
         for (const t of token.children) {
-          if (isComment(t) && applyDirectives(t.meta.marpitParsedDirectives))
-            markAsParsed(t)
+          if (
+            isDirectiveComment(t) &&
+            applyDirectives(t.meta.marpitParsedDirectives)
+          )
+            markAsParsed(t, 'directive')
         }
       }
     }

--- a/test/markdown/collect.js
+++ b/test/markdown/collect.js
@@ -140,19 +140,19 @@ describe('Marpit collect plugin', () => {
     })
 
     it('ignores comments for well-known linters and formatters by default', () => {
-      const comment = markdown => {
+      const comments = markdown => {
         const marpit = marpitStub()
         md(marpit).render(markdown)
 
         return marpit.lastComments[0]
       }
 
-      expect(comment('<!-- regular comment -->')).toHaveLength(1)
+      expect(comments('<!-- regular comment -->')).toHaveLength(1)
 
       // Prettier
-      expect(comment('<!-- prettier-ignore -->')).toHaveLength(0)
+      expect(comments('<!-- prettier-ignore -->')).toHaveLength(0)
       expect(
-        comment(dedent`
+        comments(dedent`
           <!--  prettier-ignore-start  -->
           <!-- test -->
           <!--prettier-ignore-end-->
@@ -161,14 +161,14 @@ describe('Marpit collect plugin', () => {
 
       // markdownlint
       expect(
-        comment(dedent`
+        comments(dedent`
           <!-- markdownlint-disable no-space-in-emphasis -->
           deliberate space * in * emphasis
           <!-- markdownlint-enable no-space-in-emphasis -->
         `)
       ).toHaveLength(0)
       expect(
-        comment(dedent`
+        comments(dedent`
           <!-- markdownlint-capture -->
           <!-- markdownlint-disable -->
           any violations you want
@@ -177,10 +177,10 @@ describe('Marpit collect plugin', () => {
       ).toHaveLength(0)
 
       // remark-lint (remark-message-control)
-      expect(comment('<!--lint disable-->')).toHaveLength(0)
-      expect(comment('<!--lint enable-->')).toHaveLength(0)
+      expect(comments('<!--lint disable-->')).toHaveLength(0)
+      expect(comments('<!--lint enable-->')).toHaveLength(0)
       expect(
-        comment(dedent`
+        comments(dedent`
           # Hello
 
           <!--lint disable no-duplicate-headings-->
@@ -191,7 +191,7 @@ describe('Marpit collect plugin', () => {
         `)
       ).toHaveLength(0)
       expect(
-        comment(dedent`
+        comments(dedent`
           <!--lint ignore list-item-bullet-indent strong-marker-->
 
           *   **foo**

--- a/test/markdown/collect.js
+++ b/test/markdown/collect.js
@@ -2,7 +2,7 @@ import dedent from 'dedent'
 import MarkdownIt from 'markdown-it'
 import applyDirectives from '../../src/markdown/directives/apply'
 import collect from '../../src/markdown/collect'
-import comment from '../../src/markdown/comment'
+import comment, { markAsParsed } from '../../src/markdown/comment'
 import inlineSVG from '../../src/markdown/inline_svg'
 import parseDirectives from '../../src/markdown/directives/parse'
 import slide from '../../src/markdown/slide'
@@ -109,46 +109,97 @@ describe('Marpit collect plugin', () => {
     expect(lastComments[3]).toStrictEqual(['inline comment'])
   })
 
-  context(
-    'when comment token is marked marpitCommentParsed meta in other plugin',
-    () => {
-      it('ignores collecting comment', () => {
-        const marpit = marpitStub()
+  context('when comment token is marked as parsed by #markAsParsed', () => {
+    it('ignores collecting comment', () => {
+      const marpit = marpitStub()
 
-        md(marpit)
-          .use(mdIt => {
-            mdIt.core.ruler.before(
-              'marpit_slide',
-              'marpit_test_inject',
-              state => {
-                const markParsed = token => {
-                  token.meta = {
-                    ...(token.meta || {}),
-                    marpitCommentParsed: 'test',
-                  }
-                }
-
-                for (const token of state.tokens) {
-                  if (token.content === 'This is comment') {
-                    markParsed(token)
-                  } else if (token.type === 'inline') {
-                    for (const t of token.children)
-                      if (t.content === 'inline comment') markParsed(t)
-                  }
+      md(marpit)
+        .use(mdIt => {
+          mdIt.core.ruler.before(
+            'marpit_slide',
+            'marpit_test_inject',
+            state => {
+              for (const token of state.tokens) {
+                if (token.content === 'This is comment') {
+                  markAsParsed(token, 'test')
+                } else if (token.type === 'inline') {
+                  for (const t of token.children)
+                    if (t.content === 'inline comment') markAsParsed(t, 'test')
                 }
               }
-            )
-          })
-          .render(text)
+            }
+          )
+        })
+        .render(text)
 
-        const { lastComments } = marpit
+      const { lastComments } = marpit
 
-        expect(lastComments[0]).toHaveLength(1)
-        expect(lastComments[0]).not.toContain('This is comment')
-        expect(lastComments[3]).toHaveLength(0)
-      })
-    }
-  )
+      expect(lastComments[0]).toHaveLength(1)
+      expect(lastComments[0]).not.toContain('This is comment')
+      expect(lastComments[3]).toHaveLength(0)
+    })
+
+    it('ignores comments for well-known linters and formatters by default', () => {
+      const comment = markdown => {
+        const marpit = marpitStub()
+        md(marpit).render(markdown)
+
+        return marpit.lastComments[0]
+      }
+
+      expect(comment('<!-- regular comment -->')).toHaveLength(1)
+
+      // Prettier
+      expect(comment('<!-- prettier-ignore -->')).toHaveLength(0)
+      expect(
+        comment(dedent`
+          <!--  prettier-ignore-start  -->
+          <!-- test -->
+          <!--prettier-ignore-end-->
+        `)
+      ).toHaveLength(1)
+
+      // markdownlint
+      expect(
+        comment(dedent`
+          <!-- markdownlint-disable no-space-in-emphasis -->
+          deliberate space * in * emphasis
+          <!-- markdownlint-enable no-space-in-emphasis -->
+        `)
+      ).toHaveLength(0)
+      expect(
+        comment(dedent`
+          <!-- markdownlint-capture -->
+          <!-- markdownlint-disable -->
+          any violations you want
+          <!-- markdownlint-restore -->
+        `)
+      ).toHaveLength(0)
+
+      // remark-lint (remark-message-control)
+      expect(comment('<!--lint disable-->')).toHaveLength(0)
+      expect(comment('<!--lint enable-->')).toHaveLength(0)
+      expect(
+        comment(dedent`
+          # Hello
+
+          <!--lint disable no-duplicate-headings-->
+
+          ## Hello
+
+          <!-- lint enable no-duplicate-headings -->
+        `)
+      ).toHaveLength(0)
+      expect(
+        comment(dedent`
+          <!--lint ignore list-item-bullet-indent strong-marker-->
+
+          *   **foo**
+            * __bar__
+        `)
+      ).toHaveLength(0)
+    })
+  })
 
   context('with inline SVG mode', () => {
     it('includes inline SVG tokens in collected result', () => {


### PR DESCRIPTION
Resolves #191.

Marpit collect plugin won't collect comments that have `marpitCommentParsed` meta. So comment plugin will mark well-known magic comments as parsed, through refactored `markAsParsed` function (Extract from directive plugin).