### PR TITLE
Apply workaround for glitched video control on Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply workaround for glitched video control on Chromium ([#205](https://github.com/marp-team/marpit/issues/205), [#208](https://github.com/marp-team/marpit/pull/208))
+
 ### Changed
 
 - Upgrade Node for development to v12 LTS ([#202](https://github.com/marp-team/marpit/pull/202))

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -32,6 +32,10 @@ h1 {
   font-size: 2em;
   margin: 0.67em 0;
 }
+
+video::-webkit-media-controls {
+  will-change: transform;
+}
 `.trim()
 
 /**
@@ -40,6 +44,7 @@ h1 {
  * - Define the default slide size.
  * - Set default style for `<section>`.
  * - Normalize `<h1>` heading style.
+ * - Apply workaround for glitched video control on Chromium (https://github.com/marp-team/marpit/issues/205)
  *
  * @alias module:theme/scaffold
  * @type {Theme}


### PR DESCRIPTION
Even if enabled BGPT feature on Chromium, the video control on inline SVG mode has glitched rendering as like as https://github.com/marp-team/marp-cli/pull/15.

`will-change: transform` enables hardware acelaration while rendering. It reduces glitch for control.

Fix #205.

> However, it's not yet resolved all of problems. The context menu still has incorrect position.