### PR TITLE
Update community health files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,12 +2,7 @@
 
 Thank you for taking the time to read how to contribute to Marpit! This is the guideline for contributing to Marpit.
 
-We are following [the contributing guideline of marp-team projects](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md). Please read this before starting work.
-
-- [**Code of Conduct**](https://github.com/marp-team/marp/blob/master/.github/CODE_OF_CONDUCT.md)
-- [**Report issue**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#report-issue)
-- [**Pull request**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#pull-request)
-- [**Release**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#release)
+We are following [**the contributing guideline of Marp team projects**](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md). _You have to read this before starting work._
 
 ## Development
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [yhatt]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Upgrade dependent packages to the latest version ([#211](https://github.com/marp-team/marpit/pull/211))
+- Update community health files ([#212](https://github.com/marp-team/marpit/pull/212))
 
 ## v1.4.2 - 2019-11-06
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn build
 
 ## Contributing
 
-Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) and [the common contributing guideline for Marp team](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md).
 
 ## Sub-projects
 


### PR DESCRIPTION
Marp team's common health files such as CONTRIBUTING.md were moved to [`.github` repository](https://github.com/marp-team/.github).
