### PR TITLE
Scope keyframe names defined in <style scoped>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Make scoped keyframe names if defined `@keyframes` in `<style scoped>` ([#231](https://github.com/marp-team/marpit/issues/231), [#237](https://github.com/marp-team/marpit/pull/237))
+
 ## v1.5.3 - 2020-05-04
 
 ### Fixed

--- a/src/markdown/style/assign.js
+++ b/src/markdown/style/assign.js
@@ -7,7 +7,8 @@ const uniqKeyChars =
 
 const uniqKeyCharsLength = uniqKeyChars.length
 
-function generateUniqKey(length = 8) {
+const generateScopeAttr = (uniqKey) => `data-marpit-scope-${uniqKey}`
+const generateUniqKey = (length = 8) => {
   let ret = ''
 
   for (let i = 0; i < length; i += 1)
@@ -18,19 +19,44 @@ function generateUniqKey(length = 8) {
 
 const injectScopePostCSSplugin = postcss.plugin(
   'marpit-style-assign-postcss-inject-scope',
-  (attr) => (css) =>
-    css.walkRules((rule) => {
-      const { type, name } = rule.parent
-      if (type === 'atrule' && name === 'keyframes') return
+  (key, keyframeSet) => (css) =>
+    css.each(function inject(node) {
+      const { type, name } = node
 
-      rule.selectors = rule.selectors.map((selector) => {
-        const injectSelector = /^section(?![\w-])/.test(selector)
-          ? selector.slice(7)
-          : ` ${selector}`
+      if (type === 'atrule') {
+        if (name === 'keyframes' && node.params) {
+          keyframeSet.add(node.params)
+          node.params += `-${key}`
+        } else if (name === 'media' || name === 'supports') {
+          node.each(inject)
+        }
+      } else if (type === 'rule') {
+        node.selectors = node.selectors.map((selector) => {
+          const injectSelector = /^section(?![\w-])/.test(selector)
+            ? selector.slice(7)
+            : ` ${selector}`
 
-        return `section[${attr}]${injectSelector}`
-      })
+          return `section[${generateScopeAttr(key)}]${injectSelector}`
+        })
+      }
     })
+)
+
+const scopeKeyframesPostCSSPlugin = postcss.plugin(
+  'marpit-style-assign-postcss-scope-keyframes',
+  (key, keyframeSet) => (css) => {
+    if (keyframeSet.size === 0) return
+
+    const keyframeMatcher = new RegExp(
+      `\\b(${[...keyframeSet.values()]
+        .map((kf) => kf.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'))
+        .join('|')})(?!\\()\\b`
+    )
+
+    css.walkDecls(/^animation(-name)?$/, (decl) => {
+      decl.value = decl.value.replace(keyframeMatcher, (kf) => `${kf}-${key}`)
+    })
+  }
 )
 
 /**
@@ -57,33 +83,69 @@ function assign(md) {
       if (token.meta && token.meta.marpitSlideElement === 1) {
         current = token
       } else if (token.meta && token.meta.marpitSlideElement === -1) {
+        if (current.meta && current.meta.marpitStyleScoped) {
+          const { key, keyframeSet, styles } = current.meta.marpitStyleScoped
+
+          // Rewrite keyframes name in animation decls
+          const processor = postcss([
+            scopeKeyframesPostCSSPlugin(key, keyframeSet),
+          ])
+
+          current.meta.marpitStyleScoped.styles = styles.map((style) => {
+            try {
+              return processor.process(style).css
+            } catch (e) {
+              return style
+            }
+          })
+
+          // Assign scoped styles
+          marpit.lastStyles.push(...current.meta.marpitStyleScoped.styles)
+        }
         current = undefined
       } else if (token.type === 'marpit_style') {
-        let { content } = token
+        const { content } = token
 
-        // Scoped style into current page
+        // Scoped style
         const { marpitStyleScoped } = token.meta || {}
 
         if (current && marpitStyleScoped) {
-          let metaAttr = current.meta.marpitScopeMeta
+          current.meta = current.meta || {}
+          current.meta.marpitStyleScoped = current.meta.marpitStyleScoped || {}
 
-          if (!metaAttr) {
-            metaAttr = `data-marpit-scope-${generateUniqKey()}`
+          let { key } = current.meta.marpitStyleScoped
 
-            current.meta.marpitScopeMeta = metaAttr
-            current.attrSet(metaAttr, '')
+          if (!key) {
+            key = generateUniqKey()
+
+            current.meta.marpitStyleScoped.key = key
+            current.attrSet(generateScopeAttr(key), '')
           }
 
-          const processor = postcss([injectScopePostCSSplugin(metaAttr)])
+          current.meta.marpitStyleScoped.styles =
+            current.meta.marpitStyleScoped.styles || []
+
+          current.meta.marpitStyleScoped.keyframeSet =
+            current.meta.marpitStyleScoped.keyframeSet || new Set()
+
+          const processor = postcss([
+            injectScopePostCSSplugin(
+              key,
+              current.meta.marpitStyleScoped.keyframeSet
+            ),
+          ])
 
           try {
-            content = processor.process(content).css
+            current.meta.marpitStyleScoped.styles.push(
+              processor.process(content).css
+            )
           } catch (e) {
-            content = undefined
+            // No ops
           }
+        } else if (content) {
+          // Global style
+          marpit.lastStyles.push(content)
         }
-
-        if (content) marpit.lastStyles.push(content)
       }
     }
   })


### PR DESCRIPTION
When defined `@keyframes` in `<style scoped>`, Marpit will scope the keyframe name, and replace the keyframe name defined in `animation` and `animation-name` declarations within `<style scoped>` into scoped keyframe.

It's helpful for defining slide animations without thinking about confliction with global animation keyframes.


```html
<style scoped>
@keyframes local-animation {
  from { transform: translateX(100%); }
  to { transform: none; }
}
h1 {
  animation: 1s ease-out local-animation;
}
</style>
```

The above definition will transform into this:

```css
@keyframes local-animation-RVSdalDm {
  from { transform: translateX(100%); }
  to { transform: none; }
}

div.marpit > section[data-marpit-scope-RVSdalDm] h1 {
  animation: 1s ease-out local-animation-RVSdalDm;
}
```

Marpit will replace only animation names defined by `<style scoped>` in the same slide. So global animation keyframes are still working.

Resolves #231.