### PR TITLE
Disable animations and transitions in print CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Make scoped keyframe names if defined `@keyframes` in `<style scoped>` ([#231](https://github.com/marp-team/marpit/issues/231), [#237](https://github.com/marp-team/marpit/pull/237))
 
+### Fixed
+
+- Disable CSS transitions and animations in the style for print ([#238](https://github.com/marp-team/marpit/issues/238), [#239](https://github.com/marp-team/marpit/pull/239))
+
 ## v1.5.3 - 2020-05-04
 
 ### Fixed

--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -40,7 +40,10 @@ const plugin = postcss.plugin('marpit-postcss-printable', (opts) => (css) => {
 
   section, section * {
     -webkit-print-color-adjust: exact !important;
+    animation-delay: 0s !important;
+    animation-duration: 0s !important;
     color-adjust: exact !important;
+    transition: none !important;
   }
 
   :marpit-container > svg[data-marpit-svg] {


### PR DESCRIPTION
Disable CSS animations and transitions through styles for print that is injected by Marpit printable PostCSS plugin.

We are using `animation-duration: 0s !important` and `animation-delay: 0s !important` instead of `animation: none !important`. If disabled animationsimply, the rendered result won't reflect the state of `animation-fill-mode`.

Fix #238.