### PR TITLE
Support :root pseudo-class selector and rem unit as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Make scoped keyframe names if defined `@keyframes` in `<style scoped>` ([#231](https://github.com/marp-team/marpit/issues/231), [#237](https://github.com/marp-team/marpit/pull/237))
+- Correct support of `:root` pseudo-class selector and `rem` unit for theme CSS ([#232](https://github.com/marp-team/marpit/issues/232), [#240](https://github.com/marp-team/marpit/pull/240))
 
 ### Fixed
 

--- a/docs/theme-css.md
+++ b/docs/theme-css.md
@@ -9,7 +9,7 @@ The basic idea of HTML structure is that `<section>` elements are corresponding 
 <section><h1>Second page</h1></section>
 ```
 
-?> When conversion, Marpit would scope CSS selectors by wrapping with [container element(s)](/usage#package-customize-container-elements) automatically. However, the theme creator should not aware of this process.
+?> When conversion, Marpit would scope CSS selectors by wrapping them with the selector for [container element(s)](/usage#package-customize-container-elements) automatically. However, the theme author doesn't have to be aware of this process.
 
 ## Create theme CSS
 
@@ -35,11 +35,11 @@ h2 {
 }
 ```
 
-We have no any predefined classes or mixins, and don't need require extra definitions for creating theme. This is a key factor different from other slide framework.
+We have no any extra classes or mixins, and do almost not need require to know extra rules for creating theme. This is a key factor of Marpit different from other slide framework.
 
 ### Metadata
 
-We can parse any metadata in CSS comments. Especially the `@theme` metadata is always required by Marpit.
+The `@theme` metadata is always required by Marpit. Define metadata through CSS comment.
 
 ```css
 /* @theme name */
@@ -47,15 +47,44 @@ We can parse any metadata in CSS comments. Especially the `@theme` metadata is a
 
 !> You should use the `/*! comment */` syntax to prevent removing comments if you're using the compressed output of [Sass].
 
+### `:root` pseudo-class selector
+
+Since v1.6.0, [`:root` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:root) indicates the viewport of each slide pages in the context of Marpit theme CSS, by replacing `:root` into `section` automatically.
+
+The following is similar theme definition to the example shown earlier, but it's using `:root` selector.
+
+```css
+/* @theme marpit-theme */
+
+:root {
+  width: 1280px;
+  height: 960px;
+  font-size: 40px;
+  padding: 1rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  color: #09c;
+}
+
+h2 {
+  font-size: 1.25rem;
+}
+```
+
+[`rem` units](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Rems) in Marpit theme will automatically transform into the calculated relative value from the parent `<section>` element, so anyone don't have to worry the effect from `font-size` in the root `<html>` that placed Marpit slide. Everything would work as the theme author expected.
+
 ## Styling
 
 ### Slide size
 
-`width` and `height` declaration in the root `section` selector mean a predefined slide size per theme. The specified size is not only used in the section element size but also in the size of printed PDF.
+`width` and `height` declarations in the root `section` selector or `:root` pseudo-class selector mean a predefined slide size per theme. The specified size is not only used as the size of section element but also as the size of PDF for printing.
 
 The default size is `1280` x `720` pixels. Try this if you want a classic 4:3 slide:
 
 ```css
+/* Change to the classic 4:3 slide */
 section {
   width: 960px;
   height: 720px;
@@ -64,11 +93,11 @@ section {
 
 !> Please notice _it must define the length in **an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, and `px`.
 
-?> It is determined one size per theme. The slide size cannot tweak through using [inline style](#tweak-style-through-markdown) or [custom class](/directives#class), but may shrink the width of contents if user was using [split backgrounds](/image-syntax#split-backgrounds).
+?> It is determined **one size per theme** in Marpit. The slide size cannot tweak through using [inline style](#tweak-style-through-markdown) or [custom class](/directives#class). But may shrink the width of contents if user was using [split backgrounds](/image-syntax#split-backgrounds).
 
 ### Pagination
 
-[`paginate` local directive](/directives#pagination) may control whether show the page number of slide. The theme creator can style it through `section::after` pseudo-element.
+[`paginate` local directive](/directives#pagination) may control whether show the page number of slide. The theme creator can style it through `section::after` (`:root::after`) pseudo-element.
 
 ```css
 /* Styling page number */
@@ -97,7 +126,7 @@ section::after {
 
 `attr(data-marpit-pagination-total)` means the total page number of rendered slides. Thus, the above example would show as like as `Page 1 / 3`.
 
-!> Theme CSS must contain `attr(data-marpit-pagination)` in `content` declaration because user expects to show the page number by `paginate: true` directive. Marpit will ignore the whole of `content` declaration if the reference to that attribute is not contained.
+!> Theme CSS must contain `attr(data-marpit-pagination)` in `content` declaration because user expects to show the page number by `paginate: true` directive. _Marpit will ignore the whole of `content` declaration if the reference to that attribute is not contained._
 
 ### Header and footer
 
@@ -183,7 +212,7 @@ section {
 
 Sometimes you might think that want to tweak current theme instead of customizing theme fully.
 
-Marpit gives the `<style>` HTML element a special treatment. The specified inline style would parse in the context of as same as a theme, and bundle to the converted CSS together with it.
+Marpit gives the `<style>` HTML element written in Markdown a special treatment. The specified inline style would parse in the context of as same as a theme, and bundle to the converted CSS together with it.
 
 ```markdown
 ---
@@ -201,13 +230,13 @@ section {
 You would see a yellow slide.
 ```
 
-`<style>` elements would not find in rendered HTML, and would merge into CSS.
+`<style>` elements would not find in rendered HTML, and would merge into emitted CSS.
 
 [`style` global directive](/directives#tweak-theme-style) also can use as same purpose.
 
 ### Scoped style
 
-We also support the scoped inline style through `<style scoped>`. When a `style` element has the `scoped` attribute, its style will apply to the current slide page only.
+We also support the scoped inline style through `<style scoped>`. When a `style` element has the `scoped` attribute, its style will apply only to the current slide page only.
 
 ```markdown
 <!-- Global style -->

--- a/src/postcss/root/rem.js
+++ b/src/postcss/root/rem.js
@@ -1,0 +1,30 @@
+/** @module */
+import postcss from 'postcss'
+import { rootFontSizeCustomProp } from './replace'
+
+const skipParsingMatcher = /("[^"]*"|'[^']*'|(?:attr|url|var)\([^)]*\))/g
+
+/**
+ * Marpit PostCSS rem plugin.
+ *
+ * Replace `rem` unit to calculated value from CSS variable.
+ *
+ * @alias module:postcss/root/rem
+ */
+const plugin = postcss.plugin('marpit-postcss-rem', () => (css) =>
+  css.walkDecls((decl) => {
+    decl.value = decl.value
+      .split(skipParsingMatcher)
+      .map((v, i) => {
+        if (i % 2) return v
+
+        return v.replace(
+          /(\d*\.?\d+)rem\b/g,
+          (_, num) => `calc(var(${rootFontSizeCustomProp}, 1rem) * ${num})`
+        )
+      })
+      .join('')
+  })
+)
+
+export default plugin

--- a/src/postcss/root/replace.js
+++ b/src/postcss/root/replace.js
@@ -1,0 +1,69 @@
+/** @module */
+import postcss from 'postcss'
+
+export const rootFontSizeCustomProp = '--marpit-root-font-size'
+
+/**
+ * Marpit PostCSS root replace plugin.
+ *
+ * Replace `:root` pseudo-class selector into `section`, and inject CSS variable
+ * for correct calculation of rem unit in `font-size` declaration.
+ *
+ * @alias module:postcss/root/replace
+ */
+const plugin = postcss.plugin('marpit-postcss-root-replace', () => (css) =>
+  css.walkRules((rule) => {
+    if (!rule.parent) return
+
+    const { type, name } = rule.parent
+    if (type === 'atrule' && name === 'keyframes') return
+
+    const injectSelector = new Set()
+
+    rule.selectors = rule.selectors.map((selector) => {
+      // Replace `:root` pseudo-class selectors into `section`
+      const replaced = selector.replace(
+        /(^|[\s>+~(]):root\b/g,
+        (_, s) => `${s}section`
+      )
+
+      // Detect whether the selector is targeted to section
+      const parentSelectors = replaced.split(/(\s+|\s*[>~+]\s*)/)
+      const targetSelector = parentSelectors.pop()
+      const delimiterMatched = targetSelector.match(/[.:#[]/)
+      const target = delimiterMatched
+        ? targetSelector.slice(0, delimiterMatched.index)
+        : targetSelector
+
+      if (target === 'section' || target.endsWith('*') || target === '') {
+        // Generate selector for injection
+        injectSelector.add(
+          [
+            ...parentSelectors,
+            target === 'section'
+              ? 'section'
+              : ':marpit-container > :marpit-slide section', // Universal selector is targeted to the children `section` of root `section`
+            delimiterMatched
+              ? targetSelector.slice(delimiterMatched.index)
+              : '',
+          ].join('')
+        )
+      }
+
+      return replaced
+    })
+
+    if (injectSelector.size === 0) return
+
+    // Inject CSS variable
+    const injectRule = postcss.rule({ selectors: [...injectSelector.values()] })
+
+    rule.walkDecls('font-size', (decl) => {
+      injectRule.append(decl.clone({ prop: rootFontSizeCustomProp }))
+    })
+
+    if (injectRule.nodes.length > 0) rule.parent.insertAfter(rule, injectRule)
+  })
+)
+
+export default plugin

--- a/src/postcss/root/replace.js
+++ b/src/postcss/root/replace.js
@@ -13,17 +13,12 @@ export const rootFontSizeCustomProp = '--marpit-root-font-size'
  */
 const plugin = postcss.plugin('marpit-postcss-root-replace', () => (css) =>
   css.walkRules((rule) => {
-    if (!rule.parent) return
-
-    const { type, name } = rule.parent
-    if (type === 'atrule' && name === 'keyframes') return
-
     const injectSelector = new Set()
 
     rule.selectors = rule.selectors.map((selector) => {
       // Replace `:root` pseudo-class selectors into `section`
       const replaced = selector.replace(
-        /(^|[\s>+~(]):root\b/g,
+        /(^|[\s>+~(])(?:section)?:root\b/g,
         (_, s) => `${s}section`
       )
 

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -9,6 +9,8 @@ import postcssPrintable, {
 } from './postcss/printable'
 import postcssPseudoPrepend from './postcss/pseudo_selector/prepend'
 import postcssPseudoReplace from './postcss/pseudo_selector/replace'
+import postcssRem from './postcss/root/rem'
+import postcssRootReplace from './postcss/root/replace'
 import Theme from './theme'
 import scaffold from './theme/scaffold'
 
@@ -267,9 +269,11 @@ class ThemeSet {
         theme !== scaffold && ((css) => css.first.before(scaffold.css)),
         opts.inlineSVG && postcssAdvancedBackground,
         postcssPagination,
+        postcssRootReplace,
         postcssPseudoPrepend,
         postcssPseudoReplace(opts.containers, slideElements),
         opts.printable && postcssPrintablePostProcess,
+        postcssRem,
         postcssImportRollup,
       ].filter((p) => p)
     )

--- a/test/postcss/root/rem.js
+++ b/test/postcss/root/rem.js
@@ -1,0 +1,59 @@
+import dedent from 'dedent'
+import postcss from 'postcss'
+import { rootFontSizeCustomProp } from '../../../src/postcss/root/replace'
+import rem from '../../../src/postcss/root/rem'
+
+describe('Marpit PostCSS rem plugin', () => {
+  const run = (input) => postcss([rem()]).process(input, { from: undefined })
+
+  it('replaces rem unit in all declarations into calculated value', () => {
+    expect(run('h1 { font-size: 2rem; }').css).toBe(
+      `h1 { font-size: calc(var(${rootFontSizeCustomProp}, 1rem) * 2); }`
+    )
+
+    expect(
+      run(dedent`
+        h2 { font-size: 1.5rem; }
+        h3 { font-size: .9rem; }
+      `).css
+    ).toBe(dedent`
+      h2 { font-size: calc(var(${rootFontSizeCustomProp}, 1rem) * 1.5); }
+      h3 { font-size: calc(var(${rootFontSizeCustomProp}, 1rem) * .9); }
+    `)
+
+    expect(
+      run('@media screen { h4 { height: calc(12px + .6rem); } }').css
+    ).toBe(
+      `@media screen { h4 { height: calc(12px + calc(var(${rootFontSizeCustomProp}, 1rem) * .6)); } }`
+    )
+  })
+
+  it('does not replace the quoted rem unit', () => {
+    const singleQuote = 'section::after { content: "1rem"; }'
+    expect(run(singleQuote).css).toBe(singleQuote)
+
+    const doubleQuote = "section::after { content: '1rem'; }"
+    expect(run(doubleQuote).css).toBe(doubleQuote)
+
+    // The case of mixed
+    expect(run("section { font: regular 2rem '2rem font'; }").css).toBe(
+      `section { font: regular calc(var(${rootFontSizeCustomProp}, 1rem) * 2) '2rem font'; }`
+    )
+  })
+
+  it('does not replace a string like rem unit in some functions', () => {
+    const url = 'section { background: url(https://example.com/1rem.png); }'
+    expect(run(url).css).toBe(url)
+
+    const attr = 'section::after { content: attr(data-1rem); }'
+    expect(run(attr).css).toBe(attr)
+
+    const varFunc = 'section::after { content: var(--text-1rem); }'
+    expect(run(varFunc).css).toBe(varFunc)
+  })
+
+  it('does not replace custom value definition of confusable to rem', () => {
+    const css = ':root { --test: 1remy; }'
+    expect(run(css).css).toBe(css)
+  })
+})

--- a/test/postcss/root/replace.js
+++ b/test/postcss/root/replace.js
@@ -1,0 +1,144 @@
+import dedent from 'dedent'
+import postcss from 'postcss'
+import replace, {
+  rootFontSizeCustomProp,
+} from '../../../src/postcss/root/replace'
+import prependSlide from '../../../src/postcss/pseudo_selector/prepend'
+import replaceSlide from '../../../src/postcss/pseudo_selector/replace'
+
+describe('Marpit PostCSS root replace plugin', () => {
+  const run = (input, plugins = []) =>
+    postcss([replace()].concat(plugins)).process(input, { from: undefined })
+
+  it('replaces ":root" pseudo-class selector into "section"', () => {
+    expect(run(':root { --bg: #fff; }').css).toBe('section { --bg: #fff; }')
+
+    // Various usages of :root selector
+    expect(run(':root :root { --bg: #fff; }').css).toBe(
+      'section section { --bg: #fff; }'
+    )
+    expect(run(':marpit-slide>:root { --bg: #fff; }').css).toBe(
+      ':marpit-slide>section { --bg: #fff; }'
+    )
+    expect(run(':root+:root { --bg: #fff; }').css).toBe(
+      'section+section { --bg: #fff; }'
+    )
+    expect(run(':root.klass~:root { --bg: #fff; }').css).toBe(
+      'section.klass~section { --bg: #fff; }'
+    )
+    expect(run(':root:not(:root.klass) { --bg: #fff; }').css).toBe(
+      'section:not(section.klass) { --bg: #fff; }'
+    )
+    expect(
+      run(dedent`
+        @media screen {
+          :root { --bg: #fff; }
+        }
+      `).css
+    ).toContain('section { --bg: #fff; }')
+    expect(
+      run(dedent`
+        @supports (--foo: bar) {
+          :root { --bg: #fff; }
+        }
+      `).css
+    ).toContain('section { --bg: #fff; }')
+
+    // "section:root" also replaces into "section"
+    expect(run('section:root { --bg: #fff; }').css).toBe(
+      'section { --bg: #fff; }'
+    )
+  })
+
+  it('does not replace ":root" in non-selector', () => {
+    expect(run('p[data-value=":root"] { --bg: #fff; }').css).toBe(
+      'p[data-value=":root"] { --bg: #fff; }'
+    )
+  })
+
+  it('leaves :root selector for other elements', () => {
+    expect(run('html:root :root { --bg: #fff; }').css).toBe(
+      'html:root section { --bg: #fff; }'
+    )
+  })
+
+  describe('CSS variable injection', () => {
+    const runWithModularize = (css) => run(css, [prependSlide, replaceSlide()])
+
+    it('injects CSS custom property reflected with font-size declarations for the root section', () => {
+      const expected = dedent`
+        section { font-size: 16px; }
+        section { ${rootFontSizeCustomProp}: 16px; }
+      `
+      expect(run('section { font-size: 16px; }').css).toBe(expected)
+      expect(run(':root { font-size: 16px; }').css).toBe(expected)
+
+      // With combinator
+      expect(run(':root.klass { font-size: 16px; }').css).toContain(
+        `section.klass { ${rootFontSizeCustomProp}: 16px; }`
+      )
+      expect(run(':root#id { font-size: 16px; }').css).toContain(
+        `section#id { ${rootFontSizeCustomProp}: 16px; }`
+      )
+      expect(run(':root[data-header] { font-size: 16px; }').css).toContain(
+        `section[data-header] { ${rootFontSizeCustomProp}: 16px; }`
+      )
+      expect(run(':root:hover { font-size: 16px; }').css).toContain(
+        `section:hover { ${rootFontSizeCustomProp}: 16px; }`
+      )
+      expect(run(':root::after { font-size: 16px; }').css).toContain(
+        `section::after { ${rootFontSizeCustomProp}: 16px; }`
+      )
+
+      // Universal selector in modularized transform (explicit and implicit)
+      expect(runWithModularize('* { font-size: 16px; }').css).toBe(dedent`
+        section * { font-size: 16px; }
+        section section { ${rootFontSizeCustomProp}: 16px; }
+      `)
+      expect(runWithModularize('*|* { font-size: 16px; }').css).toBe(dedent`
+        section *|* { font-size: 16px; }
+        section section { ${rootFontSizeCustomProp}: 16px; }
+      `)
+      expect(runWithModularize('[data-header] { font-size: 16px; }').css)
+        .toBe(dedent`
+          section [data-header] { font-size: 16px; }
+          section section[data-header] { ${rootFontSizeCustomProp}: 16px; }
+        `)
+
+      // Nested section (For Marpit v2 and later)
+      const nested = dedent`
+        section>section { font-size: 16px; }
+        section>section { ${rootFontSizeCustomProp}: 16px; }
+      `
+      expect(
+        runWithModularize('section>section { font-size: 16px; }').css
+      ).toBe(nested)
+      expect(runWithModularize(':root>:root { font-size: 16px; }').css).toBe(
+        nested
+      )
+    })
+
+    it('keeps multiple font-size declarations in inherited custom property', () => {
+      expect(
+        run(dedent`
+          section {
+            font-size: 16px;
+            font-size: 1rem;
+            font-size: 18px !important;
+          }
+        `).css
+      ).toBe(dedent`
+        section {
+          font-size: 16px;
+          font-size: 1rem;
+          font-size: 18px !important;
+        }
+        section {
+          ${rootFontSizeCustomProp}: 16px;
+          ${rootFontSizeCustomProp}: 1rem;
+          ${rootFontSizeCustomProp}: 18px !important;
+        }
+      `)
+    })
+  })
+})


### PR DESCRIPTION
Recognize `:root` pseudo-class selector and `rem` unit and transform styles while rendering, to reflect the view that the author expected by CSS theme.

- `:root` will be transformed into `section`.
- `font-size` declarations containing in the rule targeted into `section` (includes transformed from `:root`) will assign to `section` container as `--marpit-root-font-size` CSS custom property.
- `XXrem` unit in all CSS declarations will be transformed into `calc(var(--marpit-root-font-size, 1rem) * XX)`. Thus, `rem` within the context of Marpit will always be indicated a relative size from the root element of the slide (`<section>`).

```css
:root {
  font-size: 16px;
}
h1 {
  font-size: 2rem;
}
```

The above theme CSS will transform into this CSS in the default constructor options:

```css
div.marpit > section {
  font-size: 16px;
}
div.marpit > section {
  --marpit-root-font-size: 16px;
}
div.marpit > section h1 {
  font-size: calc(var(--marpit-root-font-size, 1rem) * 2);
}
```

The theme author can use `:root` selector and `rem` unit with a familiar way, and don't have to take care of the root font size of the integrated service. And developer using Marpit also doesn't have to take care of the font size in the root and the Marpit container.

Resolves #232.

### ToDo

- [x] Add test cases