### PR TITLE
Alias `:root` selector into `section` while adding theme to fix parsing slide size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Slide size defined in `:root` selector does not reflect to the theme instance ([#244](https://github.com/marp-team/marpit/issues/244), [#246](https://github.com/marp-team/marpit/pull/246))
+
 ## v1.6.0 - 2020-05-09
 
 ### Added

--- a/docs/theme-css.md
+++ b/docs/theme-css.md
@@ -91,9 +91,9 @@ section {
 }
 ```
 
-!> Please notice _it must define the length in **an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, and `px`.
+!> Please notice _it must define **the static length in an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, and `px`.
 
-?> It is determined **one size per theme** in Marpit. The slide size cannot tweak through using [inline style](#tweak-style-through-markdown) or [custom class](/directives#class). But may shrink the width of contents if user was using [split backgrounds](/image-syntax#split-backgrounds).
+?> It is determined **one size per theme** in Marpit. The slide size cannot change through using [inline style](#tweak-style-through-markdown), [custom class](/directives#class), and [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). But the width of contents may shrink if user was using [split backgrounds](/image-syntax#split-backgrounds).
 
 ### Pagination
 

--- a/src/postcss/root/font_size.js
+++ b/src/postcss/root/font_size.js
@@ -1,0 +1,56 @@
+/** @module */
+import postcss from 'postcss'
+
+export const rootFontSizeCustomProp = '--marpit-root-font-size'
+
+/**
+ * Marpit PostCSS root font size plugin.
+ *
+ * Inject CSS variable based on the root slide container `section` for correct
+ * calculation of `rem` unit in the context of Marpit.
+ *
+ * @alias module:postcss/root/font_size
+ */
+const plugin = postcss.plugin('marpit-postcss-root-font-size', () => (css) =>
+  css.walkRules((rule) => {
+    const injectSelector = new Set()
+
+    for (const selector of rule.selectors) {
+      // Detect whether the selector is targeted to section
+      const parentSelectors = selector.split(/(\s+|\s*[>~+]\s*)/)
+      const targetSelector = parentSelectors.pop()
+      const delimiterMatched = targetSelector.match(/[.:#[]/)
+      const target = delimiterMatched
+        ? targetSelector.slice(0, delimiterMatched.index)
+        : targetSelector
+
+      if (target === 'section' || target.endsWith('*') || target === '') {
+        // Generate selector for injection
+        injectSelector.add(
+          [
+            ...parentSelectors,
+            target === 'section'
+              ? 'section'
+              : ':marpit-container > :marpit-slide section', // Universal selector is targeted to the children `section` of root `section`
+            delimiterMatched
+              ? targetSelector.slice(delimiterMatched.index)
+              : '',
+          ].join('')
+        )
+      }
+    }
+
+    if (injectSelector.size === 0) return
+
+    // Inject CSS variable
+    const injectRule = postcss.rule({ selectors: [...injectSelector.values()] })
+
+    rule.walkDecls('font-size', (decl) => {
+      injectRule.append(decl.clone({ prop: rootFontSizeCustomProp }))
+    })
+
+    if (injectRule.nodes.length > 0) rule.parent.insertAfter(rule, injectRule)
+  })
+)
+
+export default plugin

--- a/src/postcss/root/rem.js
+++ b/src/postcss/root/rem.js
@@ -1,6 +1,6 @@
 /** @module */
 import postcss from 'postcss'
-import { rootFontSizeCustomProp } from './replace'
+import { rootFontSizeCustomProp } from './font_size'
 
 const skipParsingMatcher = /("[^"]*"|'[^']*'|(?:attr|url|var)\([^)]*\))/g
 

--- a/src/postcss/root/replace.js
+++ b/src/postcss/root/replace.js
@@ -1,63 +1,22 @@
 /** @module */
 import postcss from 'postcss'
 
-export const rootFontSizeCustomProp = '--marpit-root-font-size'
-
 /**
  * Marpit PostCSS root replace plugin.
  *
- * Replace `:root` pseudo-class selector into `section`, and inject CSS variable
- * for correct calculation of rem unit in `font-size` declaration.
+ * Replace `:root` pseudo-class selector into `section`.
  *
  * @alias module:postcss/root/replace
  */
 const plugin = postcss.plugin('marpit-postcss-root-replace', () => (css) =>
   css.walkRules((rule) => {
-    const injectSelector = new Set()
-
-    rule.selectors = rule.selectors.map((selector) => {
-      // Replace `:root` pseudo-class selectors into `section`
-      const replaced = selector.replace(
+    // Replace `:root` pseudo-class selectors into `section`
+    rule.selectors = rule.selectors.map((selector) =>
+      selector.replace(
         /(^|[\s>+~(])(?:section)?:root\b/g,
         (_, s) => `${s}section`
       )
-
-      // Detect whether the selector is targeted to section
-      const parentSelectors = replaced.split(/(\s+|\s*[>~+]\s*)/)
-      const targetSelector = parentSelectors.pop()
-      const delimiterMatched = targetSelector.match(/[.:#[]/)
-      const target = delimiterMatched
-        ? targetSelector.slice(0, delimiterMatched.index)
-        : targetSelector
-
-      if (target === 'section' || target.endsWith('*') || target === '') {
-        // Generate selector for injection
-        injectSelector.add(
-          [
-            ...parentSelectors,
-            target === 'section'
-              ? 'section'
-              : ':marpit-container > :marpit-slide section', // Universal selector is targeted to the children `section` of root `section`
-            delimiterMatched
-              ? targetSelector.slice(delimiterMatched.index)
-              : '',
-          ].join('')
-        )
-      }
-
-      return replaced
-    })
-
-    if (injectSelector.size === 0) return
-
-    // Inject CSS variable
-    const injectRule = postcss.rule({ selectors: [...injectSelector.values()] })
-
-    rule.walkDecls('font-size', (decl) => {
-      injectRule.append(decl.clone({ prop: rootFontSizeCustomProp }))
-    })
-
-    if (injectRule.nodes.length > 0) rule.parent.insertAfter(rule, injectRule)
+    )
   })
 )
 

--- a/src/postcss/section_size.js
+++ b/src/postcss/section_size.js
@@ -4,7 +4,7 @@ import postcss from 'postcss'
 /**
  * Marpit PostCSS section size plugin.
  *
- * Parse width and height declartaion on section selector.
+ * Parse width and height declartaion on `section` selector.
  *
  * @alias module:postcss/section_size
  */

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,7 @@
 import postcss from 'postcss'
 import postcssImportParse from './postcss/import/parse'
 import postcssMeta from './postcss/meta'
+import postcssRootReplace from './postcss/root/replace'
 import postcssSectionSize from './postcss/section_size'
 import skipThemeValidationSymbol from './theme/symbol'
 
@@ -99,6 +100,7 @@ class Theme {
 
     const { css, result } = postcss([
       postcssMeta({ metaType }),
+      postcssRootReplace,
       postcssSectionSize,
       postcssImportParse,
     ]).process(cssString)

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -9,6 +9,7 @@ import postcssPrintable, {
 } from './postcss/printable'
 import postcssPseudoPrepend from './postcss/pseudo_selector/prepend'
 import postcssPseudoReplace from './postcss/pseudo_selector/replace'
+import postcssRootFontSize from './postcss/root/font_size'
 import postcssRem from './postcss/root/rem'
 import postcssRootReplace from './postcss/root/replace'
 import Theme from './theme'
@@ -270,6 +271,7 @@ class ThemeSet {
         opts.inlineSVG && postcssAdvancedBackground,
         postcssPagination,
         postcssRootReplace,
+        postcssRootFontSize,
         postcssPseudoPrepend,
         postcssPseudoReplace(opts.containers, slideElements),
         opts.printable && postcssPrintablePostProcess,

--- a/test/postcss/root/font_size.js
+++ b/test/postcss/root/font_size.js
@@ -1,0 +1,86 @@
+import dedent from 'dedent'
+import postcss from 'postcss'
+import prependSlide from '../../../src/postcss/pseudo_selector/prepend'
+import replaceSlide from '../../../src/postcss/pseudo_selector/replace'
+import fontSize, {
+  rootFontSizeCustomProp,
+} from '../../../src/postcss/root/font_size'
+
+describe('CSS variable injection', () => {
+  const run = (input, plugins = []) =>
+    postcss([fontSize()].concat(plugins)).process(input, { from: undefined })
+
+  const runWithModularize = (css) => run(css, [prependSlide, replaceSlide()])
+
+  it('injects CSS custom property reflected with font-size declarations for the root section', () => {
+    const expected = dedent`
+      section { font-size: 16px; }
+      section { ${rootFontSizeCustomProp}: 16px; }
+    `
+    expect(run('section { font-size: 16px; }').css).toBe(expected)
+
+    // With combinator
+    expect(run('section.klass { font-size: 16px; }').css).toContain(
+      `section.klass { ${rootFontSizeCustomProp}: 16px; }`
+    )
+    expect(run('section#id { font-size: 16px; }').css).toContain(
+      `section#id { ${rootFontSizeCustomProp}: 16px; }`
+    )
+    expect(run('section[data-header] { font-size: 16px; }').css).toContain(
+      `section[data-header] { ${rootFontSizeCustomProp}: 16px; }`
+    )
+    expect(run('section:hover { font-size: 16px; }').css).toContain(
+      `section:hover { ${rootFontSizeCustomProp}: 16px; }`
+    )
+    expect(run('section::after { font-size: 16px; }').css).toContain(
+      `section::after { ${rootFontSizeCustomProp}: 16px; }`
+    )
+
+    // Universal selector in modularized transform (explicit and implicit)
+    expect(runWithModularize('* { font-size: 16px; }').css).toBe(dedent`
+      section * { font-size: 16px; }
+      section section { ${rootFontSizeCustomProp}: 16px; }
+    `)
+    expect(runWithModularize('*|* { font-size: 16px; }').css).toBe(dedent`
+      section *|* { font-size: 16px; }
+      section section { ${rootFontSizeCustomProp}: 16px; }
+    `)
+    expect(runWithModularize('[data-header] { font-size: 16px; }').css)
+      .toBe(dedent`
+        section [data-header] { font-size: 16px; }
+        section section[data-header] { ${rootFontSizeCustomProp}: 16px; }
+      `)
+
+    // Nested section (For Marpit v2 and later)
+    const nested = dedent`
+      section>section { font-size: 16px; }
+      section>section { ${rootFontSizeCustomProp}: 16px; }
+    `
+    expect(runWithModularize('section>section { font-size: 16px; }').css).toBe(
+      nested
+    )
+  })
+
+  it('keeps multiple font-size declarations in inherited custom property', () => {
+    expect(
+      run(dedent`
+        section {
+          font-size: 16px;
+          font-size: 1rem;
+          font-size: 18px !important;
+        }
+      `).css
+    ).toBe(dedent`
+      section {
+        font-size: 16px;
+        font-size: 1rem;
+        font-size: 18px !important;
+      }
+      section {
+        ${rootFontSizeCustomProp}: 16px;
+        ${rootFontSizeCustomProp}: 1rem;
+        ${rootFontSizeCustomProp}: 18px !important;
+      }
+    `)
+  })
+})

--- a/test/postcss/root/rem.js
+++ b/test/postcss/root/rem.js
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import postcss from 'postcss'
+import { rootFontSizeCustomProp } from '../../../src/postcss/root/font_size'
 import rem from '../../../src/postcss/root/rem'
-import { rootFontSizeCustomProp } from '../../../src/postcss/root/replace'
 
 describe('Marpit PostCSS rem plugin', () => {
   const run = (input) => postcss([rem()]).process(input, { from: undefined })

--- a/test/postcss/root/replace.js
+++ b/test/postcss/root/replace.js
@@ -1,14 +1,10 @@
 import dedent from 'dedent'
 import postcss from 'postcss'
-import prependSlide from '../../../src/postcss/pseudo_selector/prepend'
-import replaceSlide from '../../../src/postcss/pseudo_selector/replace'
-import replace, {
-  rootFontSizeCustomProp,
-} from '../../../src/postcss/root/replace'
+import replace from '../../../src/postcss/root/replace'
 
 describe('Marpit PostCSS root replace plugin', () => {
-  const run = (input, plugins = []) =>
-    postcss([replace()].concat(plugins)).process(input, { from: undefined })
+  const run = (input) =>
+    postcss([replace()]).process(input, { from: undefined })
 
   it('replaces ":root" pseudo-class selector into "section"', () => {
     expect(run(':root { --bg: #fff; }').css).toBe('section { --bg: #fff; }')
@@ -60,85 +56,5 @@ describe('Marpit PostCSS root replace plugin', () => {
     expect(run('html:root :root { --bg: #fff; }').css).toBe(
       'html:root section { --bg: #fff; }'
     )
-  })
-
-  describe('CSS variable injection', () => {
-    const runWithModularize = (css) => run(css, [prependSlide, replaceSlide()])
-
-    it('injects CSS custom property reflected with font-size declarations for the root section', () => {
-      const expected = dedent`
-        section { font-size: 16px; }
-        section { ${rootFontSizeCustomProp}: 16px; }
-      `
-      expect(run('section { font-size: 16px; }').css).toBe(expected)
-      expect(run(':root { font-size: 16px; }').css).toBe(expected)
-
-      // With combinator
-      expect(run(':root.klass { font-size: 16px; }').css).toContain(
-        `section.klass { ${rootFontSizeCustomProp}: 16px; }`
-      )
-      expect(run(':root#id { font-size: 16px; }').css).toContain(
-        `section#id { ${rootFontSizeCustomProp}: 16px; }`
-      )
-      expect(run(':root[data-header] { font-size: 16px; }').css).toContain(
-        `section[data-header] { ${rootFontSizeCustomProp}: 16px; }`
-      )
-      expect(run(':root:hover { font-size: 16px; }').css).toContain(
-        `section:hover { ${rootFontSizeCustomProp}: 16px; }`
-      )
-      expect(run(':root::after { font-size: 16px; }').css).toContain(
-        `section::after { ${rootFontSizeCustomProp}: 16px; }`
-      )
-
-      // Universal selector in modularized transform (explicit and implicit)
-      expect(runWithModularize('* { font-size: 16px; }').css).toBe(dedent`
-        section * { font-size: 16px; }
-        section section { ${rootFontSizeCustomProp}: 16px; }
-      `)
-      expect(runWithModularize('*|* { font-size: 16px; }').css).toBe(dedent`
-        section *|* { font-size: 16px; }
-        section section { ${rootFontSizeCustomProp}: 16px; }
-      `)
-      expect(runWithModularize('[data-header] { font-size: 16px; }').css)
-        .toBe(dedent`
-          section [data-header] { font-size: 16px; }
-          section section[data-header] { ${rootFontSizeCustomProp}: 16px; }
-        `)
-
-      // Nested section (For Marpit v2 and later)
-      const nested = dedent`
-        section>section { font-size: 16px; }
-        section>section { ${rootFontSizeCustomProp}: 16px; }
-      `
-      expect(
-        runWithModularize('section>section { font-size: 16px; }').css
-      ).toBe(nested)
-      expect(runWithModularize(':root>:root { font-size: 16px; }').css).toBe(
-        nested
-      )
-    })
-
-    it('keeps multiple font-size declarations in inherited custom property', () => {
-      expect(
-        run(dedent`
-          section {
-            font-size: 16px;
-            font-size: 1rem;
-            font-size: 18px !important;
-          }
-        `).css
-      ).toBe(dedent`
-        section {
-          font-size: 16px;
-          font-size: 1rem;
-          font-size: 18px !important;
-        }
-        section {
-          ${rootFontSizeCustomProp}: 16px;
-          ${rootFontSizeCustomProp}: 1rem;
-          ${rootFontSizeCustomProp}: 18px !important;
-        }
-      `)
-    })
   })
 })

--- a/test/theme.js
+++ b/test/theme.js
@@ -55,6 +55,21 @@ describe('Theme', () => {
       })
     })
 
+    context('when CSS has size declarations on :root selector', () => {
+      const instance = Theme.fromCSS(dedent`
+        /* @theme test-theme */
+        :root {
+          width: 960px;
+          height: 720px;
+        }
+      `)
+
+      it('returns Theme instance that has width and height props', () => {
+        expect(instance.width).toBe('960px')
+        expect(instance.height).toBe('720px')
+      })
+    })
+
     context('when CSS has @import rules', () => {
       const instance = Theme.fromCSS(dedent`
         /* @theme test-theme */


### PR DESCRIPTION
Alias `:root` selector into `section` while adding theme, to fix parsing slide size.

Splitted out Marpit PostCSS root replace plugin into 2 plugins: Just ailasing `:root` to `section`, and inject CSS variables for `font-size` declarationf in the root `section` selector.

Continue to apply each plugins when packaging style, and apply the splitted alias plugin when adding theme too.

Fix #244.