### PR TITLE
Escape the built selector for scoping CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Escape the built selector for scoping CSS ([#256](https://github.com/marp-team/marpit/pull/256))
+
 ### Changed
 
 - Upgrade Node and dependent packages to the latest version ([#255](https://github.com/marp-team/marpit/pull/255))

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "color-string": "^1.5.3",
+    "cssesc": "^3.0.0",
     "js-yaml": "^3.14.0",
     "lodash.kebabcase": "^4.1.1",
     "markdown-it": "^11.0.0",

--- a/src/postcss/pseudo_selector/replace.js
+++ b/src/postcss/pseudo_selector/replace.js
@@ -1,4 +1,5 @@
 /** @module */
+import cssesc from 'cssesc'
 import postcss from 'postcss'
 import wrapArray from '../../helpers/wrap_array'
 
@@ -7,8 +8,11 @@ const buildSelector = (elms) =>
     .map((e) => {
       const classes = new Set((e.class || '').split(/\s+/).filter((c) => c))
 
-      let element = [e.tag, ...classes].join('.')
-      if (e.id) element += `#${e.id}`
+      let element = [e.tag, ...classes]
+        .map((c) => cssesc(c, { isIdentifier: true }))
+        .join('.')
+
+      if (e.id) element += `#${cssesc(e.id, { isIdentifier: true })}`
 
       return element
     })

--- a/test/postcss/pseudo_selector/replace.js
+++ b/test/postcss/pseudo_selector/replace.js
@@ -65,6 +65,20 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
           expect(result.root.first.selector).toBe('div > span > section')
         )
       })
+
+      it('escapes each container element names in selector', () => {
+        // These tag names can use in custom element.
+        const containers = [
+          new Element('marp.custom-element'),
+          new Element('emotion-😍'),
+        ]
+
+        return run(css, containers).then((result) =>
+          expect(result.root.first.selector).toBe(
+            'marp\\.custom-element > emotion-\\1F60D > section'
+          )
+        )
+      })
     })
 
     context('when container element has specified class', () => {
@@ -83,6 +97,16 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
           expect(result.root.first.selector).toBe('div.one.two > section')
         )
       })
+
+      it('escapes each class names in selector', () => {
+        const container = new Element('div', { class: '123 .foo.bar #test' })
+
+        return run(css, container).then((result) =>
+          expect(result.root.first.selector).toBe(
+            'div.\\31 23.\\.foo\\.bar.\\#test > section'
+          )
+        )
+      })
     })
 
     context('when container element has id', () => {
@@ -99,6 +123,16 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
 
         return run(css, container).then((result) =>
           expect(result.root.first.selector).toBe('div.one.two#id > section')
+        )
+      })
+
+      it('escapes id name in selector', () => {
+        const container = new Element('div', { id: '0123<#>4567' })
+
+        return run(css, container).then((result) =>
+          expect(result.root.first.selector).toBe(
+            'div#\\30 123\\<\\#\\>4567 > section'
+          )
         )
       })
     })
@@ -126,10 +160,23 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
 
     context('when slide element is multiple elements', () => {
       it('replaces slide into multiple elements combined by child combinator', () => {
-        const container = [new Element('svg'), new Element('foreignObject')]
+        const containers = [new Element('svg'), new Element('foreignObject')]
 
-        return run(css, undefined, container).then((result) =>
+        return run(css, undefined, containers).then((result) =>
           expect(result.root.first.selector).toBe('svg > foreignObject h1')
+        )
+      })
+
+      it('escapes each container element names in selector', () => {
+        const containers = [
+          new Element('marp.custom-element'),
+          new Element('emotion-😍'),
+        ]
+
+        return run(css, undefined, containers).then((result) =>
+          expect(result.root.first.selector).toBe(
+            'marp\\.custom-element > emotion-\\1F60D h1'
+          )
         )
       })
     })
@@ -150,6 +197,16 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
           expect(result.root.first.selector).toBe('div.one.two h1')
         )
       })
+
+      it('escapes each class names in selector', () => {
+        const container = new Element('div', { class: '123 .foo.bar #test' })
+
+        return run(css, undefined, container).then((result) =>
+          expect(result.root.first.selector).toBe(
+            'div.\\31 23.\\.foo\\.bar.\\#test h1'
+          )
+        )
+      })
     })
 
     context('when slide element has id', () => {
@@ -166,6 +223,16 @@ describe('Marpit PostCSS pseudo selector replace plugin', () => {
 
         return run(css, undefined, container).then((result) =>
           expect(result.root.first.selector).toBe('div.one.two#id h1')
+        )
+      })
+
+      it('escapes id name in selector', () => {
+        const container = new Element('div', { id: '0123<#>4567' })
+
+        return run(css, undefined, container).then((result) =>
+          expect(result.root.first.selector).toBe(
+            'div#\\30 123\\<\\#\\>4567 h1'
+          )
         )
       })
     })


### PR DESCRIPTION
When `container` option and `slideContainer` option have customized containers with specific `id` and `class`, Marpit will try to build selectors that are containing specified name as is. It may break the selector for scoping styles if contained invalid names in ID, class name(s), and the tag name defined by Custom Elements. (e.g. `class` has the name starting with number)

That leads an incorrect rendering for every Marpit slides. Thus, we've added `cssesc` package and escape invalid strings as selector at `postcss/pseudo_selector/replace` plugin.