### PR TITLE
Rename master branch to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Upgrade dependent packages to the latest version ([#276](https://github.com/marp-team/marpit/pull/276))
+- Rename `master` branch to `main` ([#279](https://github.com/marp-team/marpit/pull/279))
 
 ## v1.6.3 - 2020-12-05
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <a href="https://marpit.marp.app"><img src="https://github.com/marp-team/marpit/blob/master/docs/marpit.png?raw=true" alt="Marpit" width="500" /></a>
+  <a href="https://marpit.marp.app"><img src="https://github.com/marp-team/marpit/blob/main/docs/marpit.png?raw=true" alt="Marpit" width="500" /></a>
 </p>
 <p align="center">
   <strong>Marpit</strong>: Markdown slide deck framework
 </p>
 <p align="center">
-  <a href="https://circleci.com/gh/marp-team/marpit/"><img src="https://img.shields.io/circleci/project/github/marp-team/marpit/master.svg?style=flat-square&logo=circleci" alt="CircleCI" /></a>
-  <a href="https://codecov.io/gh/marp-team/marpit"><img src="https://img.shields.io/codecov/c/github/marp-team/marpit/master.svg?style=flat-square&logo=codecov" alt="Codecov" /></a>
+  <a href="https://circleci.com/gh/marp-team/marpit/"><img src="https://img.shields.io/circleci/project/github/marp-team/marpit/main.svg?style=flat-square&logo=circleci" alt="CircleCI" /></a>
+  <a href="https://codecov.io/gh/marp-team/marpit"><img src="https://img.shields.io/codecov/c/github/marp-team/marpit/main.svg?style=flat-square&logo=codecov" alt="Codecov" /></a>
   <a href="https://www.npmjs.com/package/@marp-team/marpit"><img src="https://img.shields.io/npm/v/@marp-team/marpit.svg?style=flat-square&logo=npm" alt="npm" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/marp-team/marpit.svg?style=flat-square" alt="LICENSE" /></a>
 </p>

--- a/api.md
+++ b/api.md
@@ -1,6 +1,6 @@
 # [Marpit API](https://marpit-api.marp.app/)
 
-The documentation of Marpit API (on `master` branch) has been published at **[https://marpit-api.marp.app/](https://marpit-api.marp.app/)**.
+The documentation of Marpit API (on `main` branch) has been published at **[https://marpit-api.marp.app/](https://marpit-api.marp.app/)**.
 
 > Please run `yarn jsdoc` if you want to build documentation at local. It would build docs in `jsdoc` directory.
 

--- a/docs/image-syntax.md
+++ b/docs/image-syntax.md
@@ -118,7 +118,7 @@ The advanced backgrounds support [multiple backgrounds][multiple], [split backgr
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/master/docs/assets/image-syntax/multiple-bg.png?raw=true" alt="Multiple backgrounds" />](/assets/image-syntax/multiple-bg.png ':ignore')
+[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/multiple-bg.png?raw=true" alt="Multiple backgrounds" />](/assets/image-syntax/multiple-bg.png ':ignore')
 
 </span>
 </div>
@@ -139,7 +139,7 @@ You may change alignment direction from horizontal to vertical, by using `vertic
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/master/docs/assets/image-syntax/multiple-bg-vertical.png?raw=true" alt="Multiple backgrounds with vertical direction" />](/assets/image-syntax/multiple-bg-vertical.png ':ignore')
+[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/multiple-bg-vertical.png?raw=true" alt="Multiple backgrounds with vertical direction" />](/assets/image-syntax/multiple-bg-vertical.png ':ignore')
 
 </span>
 </div>
@@ -160,7 +160,7 @@ The space of a slide content will shrink to the right side.
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/master/docs/assets/image-syntax/split-background.jpg?raw=true" alt="Split backgrounds" />](/assets/image-syntax/split-background.jpg ':ignore')
+[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/split-background.jpg?raw=true" alt="Split backgrounds" />](/assets/image-syntax/split-background.jpg ':ignore')
 
 </span>
 </div>
@@ -180,7 +180,7 @@ The space of a slide content will shrink to the left side.
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/master/docs/assets/image-syntax/split-multiple-bg.jpg?raw=true" alt="Split + Multiple BGs" />](/assets/image-syntax/split-multiple-bg.jpg ':ignore')
+[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/split-multiple-bg.jpg?raw=true" alt="Split + Multiple BGs" />](/assets/image-syntax/split-multiple-bg.jpg ':ignore')
 
 </span>
 </div>
@@ -203,7 +203,7 @@ Since v1.1.0, Marpit can specify split size for background by percentage like `l
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/master/docs/assets/image-syntax/split-bg-with-size.jpg?raw=true" alt="Split backgrounds with specified size" />](/assets/image-syntax/split-bg-with-size.jpg ':ignore')
+[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/split-bg-with-size.jpg?raw=true" alt="Split backgrounds with specified size" />](/assets/image-syntax/split-bg-with-size.jpg ':ignore')
 
 </span>
 </div>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -123,4 +123,4 @@ Managed by [@marp-team](https://github.com/marp-team).
 
 ## License
 
-This framework releases under the [MIT License](https://github.com/marp-team/marpit/blob/master/LICENSE).
+This framework releases under the [MIT License](https://github.com/marp-team/marpit/blob/main/LICENSE).

--- a/docs/theme-css.md
+++ b/docs/theme-css.md
@@ -107,7 +107,7 @@ section::after {
 }
 ```
 
-Please refer to [the default style of `section::after` in a scaffold theme](https://github.com/marp-team/marpit/blob/master/src/theme/scaffold.js) as well.
+Please refer to [the default style of `section::after` in a scaffold theme](https://github.com/marp-team/marpit/blob/main/src/theme/scaffold.js) as well.
 
 #### Customize content
 


### PR DESCRIPTION
It's time to rename `master` branch to `main`! Updated some codes and images that have referenced to `master` branch.