### PR TITLE
Fix broken images in marpit.marp.app documentation

### DIFF
--- a/docs/image-syntax.md
+++ b/docs/image-syntax.md
@@ -118,7 +118,7 @@ The advanced backgrounds support [multiple backgrounds][multiple], [split backgr
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/multiple-bg.png?raw=true" alt="Multiple backgrounds" />](/assets/image-syntax/multiple-bg.png ':ignore')
+[<img src="https://raw.githubusercontent.com/marp-team/marpit/main/docs/assets/image-syntax/multiple-bg.png" alt="Multiple backgrounds" />](/assets/image-syntax/multiple-bg.png ':ignore')
 
 </span>
 </div>
@@ -139,7 +139,7 @@ You may change alignment direction from horizontal to vertical, by using `vertic
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/multiple-bg-vertical.png?raw=true" alt="Multiple backgrounds with vertical direction" />](/assets/image-syntax/multiple-bg-vertical.png ':ignore')
+[<img src="https://raw.githubusercontent.com/marp-team/marpit/main/docs/assets/image-syntax/multiple-bg-vertical.png" alt="Multiple backgrounds with vertical direction" />](/assets/image-syntax/multiple-bg-vertical.png ':ignore')
 
 </span>
 </div>
@@ -160,7 +160,7 @@ The space of a slide content will shrink to the right side.
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/split-background.jpg?raw=true" alt="Split backgrounds" />](/assets/image-syntax/split-background.jpg ':ignore')
+[<img src="https://raw.githubusercontent.com/marp-team/marpit/main/docs/assets/image-syntax/split-background.jpg" alt="Split backgrounds" />](/assets/image-syntax/split-background.jpg ':ignore')
 
 </span>
 </div>
@@ -180,7 +180,7 @@ The space of a slide content will shrink to the left side.
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/split-multiple-bg.jpg?raw=true" alt="Split + Multiple BGs" />](/assets/image-syntax/split-multiple-bg.jpg ':ignore')
+[<img src="https://raw.githubusercontent.com/marp-team/marpit/main/docs/assets/image-syntax/split-multiple-bg.jpg" alt="Split + Multiple BGs" />](/assets/image-syntax/split-multiple-bg.jpg ':ignore')
 
 </span>
 </div>
@@ -203,7 +203,7 @@ Since v1.1.0, Marpit can specify split size for background by percentage like `l
 
 <span class="image">
 
-[<img src="https://github.com/marp-team/marpit/blob/main/docs/assets/image-syntax/split-bg-with-size.jpg?raw=true" alt="Split backgrounds with specified size" />](/assets/image-syntax/split-bg-with-size.jpg ':ignore')
+[<img src="https://raw.githubusercontent.com/marp-team/marpit/main/docs/assets/image-syntax/split-bg-with-size.jpg" alt="Split backgrounds with specified size" />](/assets/image-syntax/split-bg-with-size.jpg ':ignore')
 
 </span>
 </div>


### PR DESCRIPTION
#265's change by @ms10596 had made another broken images in the official documentation site https://marpit.marp.app/image-syntax.

![Screenshot_2021-02-14 Image syntax](https://user-images.githubusercontent.com/3993388/107879151-88ce8200-6f1a-11eb-9b11-882a859087f4.png)

Marp team has preferred the good look in the official documentation to GitHub Markdown.