### PR TITLE
Reset CSS columns in advanced background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Marpit requires Node.js >= 10 to install ([#284](https://github.com/marp-team/marpit/pull/284))
 
+### Fixed
+
+- Reset CSS columns in advanced background ([#283](https://github.com/marp-team/marpit/pull/283))
+
 ### Changed
 
 - Upgrade to PostCSS 8 ([#260](https://github.com/marp-team/marpit/issues/260), [#284](https://github.com/marp-team/marpit/pull/284))

--- a/src/postcss/advanced_background.js
+++ b/src/postcss/advanced_background.js
@@ -14,6 +14,7 @@ const plugin = postcss.plugin(
     css.last.after(
       `
 section[data-marpit-advanced-background="background"] {
+  columns: initial !important;
   display: block !important;
   padding: 0 !important;
 }


### PR DESCRIPTION
Reported in marp-team/marp#79.

The style for Marpit's advanced background is inheriting from specified CSS theme to keep the layout and design of theme author. However, multi-column layout by [CSS Multi-column layout module](https://www.w3.org/TR/css-multicol-1/) will break the alignment of images defined by `<figure>` tag.

Thus, I've added `columns: initial !important` to the style for `<section>` with advanced background.