### PR TITLE
Remove recognized keywords from image alternative text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove recognized image keywords from alt text ([#316](https://github.com/marp-team/marpit/issues/316), [#318](https://github.com/marp-team/marpit/pull/318))
+
 ## v2.1.2 - 2021-10-26
 
 ### Changed

--- a/src/markdown/background_image/parse.js
+++ b/src/markdown/background_image/parse.js
@@ -30,27 +30,43 @@ function backgroundImageParse(md) {
         if (t.type === 'image') {
           const { marpitImage } = t.meta
 
-          if (t.meta.marpitImage.options.includes('bg')) {
+          if (
+            marpitImage.options.some((v) => !v.consumed && v.content === 'bg')
+          ) {
             marpitImage.background = true
             t.hidden = true
 
             for (const opt of marpitImage.options) {
+              if (opt.consumed) continue
+              let consumed = false
+
+              // bg keyword
+              if (opt.content === 'bg') consumed = true
+
               // Background size keyword
-              if (bgSizeKeywords[opt])
-                marpitImage.backgroundSize = bgSizeKeywords[opt]
+              if (bgSizeKeywords[opt.content]) {
+                marpitImage.backgroundSize = bgSizeKeywords[opt.content]
+                consumed = true
+              }
 
               // Split background keyword
-              const matched = opt.match(splitSizeMatcher)
+              const matched = opt.content.match(splitSizeMatcher)
               if (matched) {
                 const [, splitSide, splitSize] = matched
 
                 marpitImage.backgroundSplit = splitSide
                 marpitImage.backgroundSplitSize = splitSize
+
+                consumed = true
               }
 
               // Background aligned direction
-              if (opt === 'vertical' || opt === 'horizontal')
-                marpitImage.backgroundDirection = opt
+              if (opt.content === 'vertical' || opt.content === 'horizontal') {
+                marpitImage.backgroundDirection = opt.content
+                consumed = true
+              }
+
+              if (consumed) opt.consumed = true
             }
           }
         }

--- a/test/markdown/image.js
+++ b/test/markdown/image.js
@@ -100,6 +100,15 @@ describe('Marpit image plugin', () => {
       expect(style('h:.678%')).not.toBe('height:.678%;')
       expect(style('h:unexpected')).not.toBe('height:unexpected;')
     })
+
+    it('removes recognized Marpit keywords from alt attribute of the output image', () => {
+      const output = md().render(
+        `![w:100px \t This is  example\timage \t h:200px](https://example.com/test.jpg)`
+      )
+      const $ = cheerio.load(output)
+
+      expect($('img').attr('alt')).toBe('This is  example\timage')
+    })
   })
 
   describe('Shorthand for text color', () => {


### PR DESCRIPTION
Updated the structure of `marpitImage` metadata, to store whether consumed the space-splitted keywords for image. When parsing process was finalized, Marpit image parse plugin will update the token to remove consumed keywords from an alternative text of the image.

Close #316.
