### PR TITLE
Inherit all attributes into the section element inside pseudo layer for advanced background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Scoped style does not style pseudo elements `section::before` and `section::after` in advanced background ([#328](https://github.com/marp-team/marpit/issues/328), [#329](https://github.com/marp-team/marpit/pull/329))
+
 ## v2.2.3 - 2022-03-27
 
 ### Changed

--- a/src/markdown/background_image/advanced.js
+++ b/src/markdown/background_image/advanced.js
@@ -137,18 +137,11 @@ function advancedBackground(md) {
                 'data-marpit-advanced-background': 'pseudo',
               },
               wrapTokens(state.Token, 'marpit_advanced_pseudo_section', {
+                ...open.attrs.reduce((o, [k, v]) => ({ ...o, [k]: v }), {}),
                 tag: 'section',
-                class: open.attrGet('class'),
+                id: undefined,
                 style: style.toString(),
                 'data-marpit-advanced-background': 'pseudo',
-
-                // For pagination styling
-                'data-marpit-pagination': open.attrGet(
-                  'data-marpit-pagination'
-                ),
-                'data-marpit-pagination-total': open.attrGet(
-                  'data-marpit-pagination-total'
-                ),
               })
             )
           )

--- a/test/markdown/style/parse.js
+++ b/test/markdown/style/parse.js
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio'
+import { load } from 'cheerio'
 import dedent from 'dedent'
 import MarkdownIt from 'markdown-it'
 import styleParse from '../../../src/markdown/style/parse'
@@ -53,7 +53,7 @@ describe('Marpit style parse plugin', () => {
       })
 
       it('strips style element in rendering', () => {
-        const $ = cheerio.load(markdown.render(text))
+        const $ = load(markdown.render(text))
         expect($('style')).toHaveLength(0)
       })
 
@@ -78,7 +78,7 @@ describe('Marpit style parse plugin', () => {
             expect(pickStyles(tokens)).toHaveLength(0)
 
             const rendered = markdown.renderer.render(tokens, markdown.options)
-            const $ = cheerio.load(rendered)
+            const $ = load(rendered)
             const code = $('code').text()
 
             expect($('style')).toHaveLength(0)


### PR DESCRIPTION
Marpit's advanced background generates 3 isolated layers for rendering advanced background images, slide contents, and generated contents by pseudo-class `::before` `::after`, such as a pagination.

The last layer we are calling "Psuedo layer" has only inherited selected attributes from the original `section` element. It brings no inheritance of the attribute for style scoping `data-marpit-scope-XXXXXXXX`, so styling to pagination `section::after` via `<style scoped>` has been ignored.

In this PR I've changed to inherit all attributes from the original `section` element into the pseudo layer. It might bring a broken style in a few cases, but I expect there is no major problem because the layer for advanced backgrounds that is working with the same inheritance logic is stable until now.

Fix #328.

Related: marp-team/marp#287