### PR TITLE
Add anchor constructor option for slide anchor customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `anchor` constructor option for slide anchor customization ([#335](https://github.com/marp-team/marpit/issues/335), [#340](https://github.com/marp-team/marpit/pull/340))
+
 ### Changed
 
 - Upgrade dependent packages to the latest version ([#339](https://github.com/marp-team/marpit/pull/339))

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare namespace MarpitEnv {
 
 declare namespace Marpit {
   interface Options {
+    anchor?: boolean | AnchorCallback
     container?: false | Element | Element[]
     headingDivider?: false | HeadingDivider | HeadingDivider[]
     looseYAML?: boolean
@@ -15,6 +16,8 @@ declare namespace Marpit {
     slideContainer?: false | Element | Element[]
     inlineSVG?: boolean | InlineSVGOptions
   }
+
+  type AnchorCallback = (index: number) => string
 
   type HeadingDivider = 1 | 2 | 3 | 4 | 5 | 6
 

--- a/src/markdown/slide.js
+++ b/src/markdown/slide.js
@@ -3,6 +3,8 @@ import split from '../helpers/split'
 import wrapTokens from '../helpers/wrap_tokens'
 import marpitPlugin from '../plugin'
 
+export const defaultAnchorCallback = (i) => `${i + 1}`
+
 /**
  * Marpit slide plugin.
  *
@@ -14,24 +16,19 @@ import marpitPlugin from '../plugin'
  * @param {Object} [opts]
  * @param {Object} [opts.attributes] The `<section>` element attributes by
  *     key-value pairs.
- * @param {(boolean|anchorCallback)} [opts.anchor=true] If true, assign the
- *     anchor with the page number starting from 1. You can customize anchor
+ * @param {(boolean|Marpit~AnchorCallback)} [opts.anchor=true] If true, assign
+ *     the anchor with the page number starting from 1. You can customize anchor
  *     name by passing callback function.
  */
 function slide(md, opts = {}) {
   const anchor = opts.anchor === undefined ? true : opts.anchor
 
-  /**
-   * Convert slide page index into anchor string.
-   *
-   * @callback anchorCallback
-   * @param {number} index Slide page index, beginning from zero.
-   * @returns {string} The text of anchor/id attribute (without prefix `#`).
-   */
-  const anchorCallback =
-    typeof anchor === 'function'
-      ? anchor
-      : (i) => (anchor ? `${i + 1}` : undefined)
+  const anchorCallback = (() => {
+    if (typeof anchor === 'function') return anchor
+    if (anchor) return defaultAnchorCallback
+
+    return () => undefined
+  })()
 
   md.core.ruler.push('marpit_slide', (state) => {
     if (state.inlineMode) return

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -12,7 +12,7 @@ import marpitHeaderAndFooter from './markdown/header_and_footer'
 import marpitHeadingDivider from './markdown/heading_divider'
 import marpitImage from './markdown/image'
 import marpitInlineSVG from './markdown/inline_svg'
-import marpitSlide from './markdown/slide'
+import marpitSlide, { defaultAnchorCallback } from './markdown/slide'
 import marpitSlideContainer from './markdown/slide_container'
 import marpitStyleAssign from './markdown/style/assign'
 import marpitStyleParse from './markdown/style/parse'
@@ -20,6 +20,7 @@ import marpitSweep from './markdown/sweep'
 import ThemeSet from './theme_set'
 
 const defaultOptions = {
+  anchor: true,
   container: marpitContainer,
   headingDivider: false,
   looseYAML: false,
@@ -49,9 +50,20 @@ class Marpit {
    */
 
   /**
+   * Convert slide page index into anchor string.
+   *
+   * @callback Marpit~AnchorCallback
+   * @param {number} index Slide page index, beginning from zero.
+   * @returns {string} The text of anchor for id attribute, without prefix `#`.
+   */
+
+  /**
    * Create a Marpit instance.
    *
    * @param {Object} [opts]
+   * @param {boolean|Marpit~AnchorCallback} [opts.anchor=true] Set the page
+   *     number as anchor of each slides (`id` attribute). You can customize the
+   *     anchor text by defining a custom callback function.
    * @param {false|Element|Element[]}
    *     [opts.container={@link module:element.marpitContainer}] Container
    *     element(s) wrapping whole slide deck.
@@ -149,9 +161,18 @@ class Marpit {
   applyMarkdownItPlugins(md) {
     this.markdown = md
 
+    const slideAnchorCallback = (...args) => {
+      const { anchor } = this.options
+
+      if (typeof anchor === 'function') return anchor(...args)
+      if (anchor) return defaultAnchorCallback(...args)
+
+      return undefined
+    }
+
     md.use(marpitComment)
       .use(marpitStyleParse)
-      .use(marpitSlide)
+      .use(marpitSlide, { anchor: slideAnchorCallback })
       .use(marpitParseDirectives)
       .use(marpitApplyDirectives)
       .use(marpitHeaderAndFooter)

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -41,6 +41,7 @@ describe('Marpit', () => {
 
     describe('options member', () => {
       it('has default options', () => {
+        expect(instance.options.anchor).toBe(true)
         expect(instance.options.container.tag).toBe('div')
         expect(instance.options.container.class).toBe('marpit')
         expect(instance.options.markdown).toBe(undefined)
@@ -450,6 +451,34 @@ describe('Marpit', () => {
         expect(style).toContain("background-image:url('/image.jpg')")
         expect(style).not.toContain('color:#123;')
         expect(style).not.toContain('background-color:#456;')
+      })
+    })
+
+    context('with anchor option', () => {
+      it('renders slides with id attribute if anchor was true', () => {
+        const marpit = new Marpit({ container: undefined, anchor: true })
+        const [token] = marpit.markdown.parse('')
+
+        expect(token.attrGet('id')).toBe('1')
+      })
+
+      it('renders slides without id attribute if anchor was false', () => {
+        const marpit = new Marpit({ container: undefined, anchor: false })
+        const [token] = marpit.markdown.parse('')
+
+        expect(token.attrGet('id')).toBeNull()
+      })
+
+      it('renders slides with custom id attribute if the function was defined as anchor option', () => {
+        const customAnchor = (index) => `custom-${index + 1}`
+
+        const marpit = new Marpit({
+          container: undefined,
+          anchor: customAnchor,
+        })
+        const [token] = marpit.markdown.parse('')
+
+        expect(token.attrGet('id')).toBe('custom-1')
       })
     })
   })


### PR DESCRIPTION
Framework users can control `id` attribute for each slides by setting `anchor` constructor option.

```javascript
// Set page number as anchor (id attribute)
new Marpit({ anchor: true })  // <section id="1">
new Marpit({ anchor: false }) // <section>

// Custom anchor: <section id="page-1">
new Marpit({ anchor: (pageIndex) => `page-${pageIndex + 1}` })
```