### PR TITLE
Improve module interface of `@marp-team/marpit/plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve module interface of `@marp-team/marpit/plugin` to make compatible with CJS ([#341](https://github.com/marp-team/marpit/pull/341))
+
 ## v2.4.0 - 2022-08-11
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,6 +153,6 @@ declare module '@marp-team/marpit' {
 }
 
 declare module '@marp-team/marpit/plugin' {
-  const pluginFactory: Marpit.PluginFactory
-  export default pluginFactory
+  export const marpitPlugin: Marpit.PluginFactory
+  export default marpitPlugin
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -21,4 +21,8 @@ function marpitPlugin(plugin) {
   }
 }
 
-export default marpitPlugin
+Object.defineProperty(marpitPlugin, '__esModule', { value: true })
+Object.defineProperty(marpitPlugin, 'default', { value: marpitPlugin })
+Object.defineProperty(marpitPlugin, 'marpitPlugin', { value: marpitPlugin })
+
+module.exports = marpitPlugin

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,0 +1,36 @@
+import markdownIt from 'markdown-it'
+import pluginAsDefaultExport from '../plugin'
+import { marpitPlugin } from '../plugin'
+import { Marpit } from '../src/index'
+
+describe('Plugin interface', () => {
+  it('is compatible as CommonJS module', () => {
+    expect(require('../plugin')).toBeInstanceOf(Function)
+  })
+
+  it('is compatible as ES Modules and able to use through default export', () => {
+    expect(pluginAsDefaultExport).toBeInstanceOf(Function)
+  })
+
+  it('is compatible as ES Modules and able to use through named export', () => {
+    expect(marpitPlugin).toBeInstanceOf(Function)
+  })
+
+  it('generates plugin function that is able to use in Marpit instance', () => {
+    const pluginFn = jest.fn((md) => md)
+    const plugin = marpitPlugin(pluginFn)
+    expect(plugin).toBeInstanceOf(Function)
+
+    const marpit = new Marpit().use(plugin)
+    expect(pluginFn).toHaveLastReturnedWith(marpit.markdown)
+    expect(marpit.markdown.marpit).toStrictEqual(marpit)
+  })
+
+  it('throws error if a generated plugin was used in markdown-it instance', () => {
+    const plugin = marpitPlugin(jest.fn())
+
+    expect(() => new markdownIt().use(plugin)).toThrowError(
+      'Marpit plugin has detected incompatible markdown-it instance.'
+    )
+  })
+})

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,11 +1,11 @@
 import markdownIt from 'markdown-it'
-import pluginAsDefaultExport from '../plugin'
-import { marpitPlugin } from '../plugin'
+import pluginAsDefaultExport from '../src/plugin'
+import { marpitPlugin } from '../src/plugin'
 import { Marpit } from '../src/index'
 
 describe('Plugin interface', () => {
   it('is compatible as CommonJS module', () => {
-    expect(require('../plugin')).toBeInstanceOf(Function)
+    expect(require('../src/plugin')).toBeInstanceOf(Function)
   })
 
   it('is compatible as ES Modules and able to use through default export', () => {


### PR DESCRIPTION
I found that usage of a plugin module through classical CJS way `require('@marp-team/marpit/plugin')` is not working.

This PR makes compatible `@marp-team/marpit/plugin` with CJS `require()`, ESM default export, and ESM named export. Now Marpit plugin example explained at https://marpit-api.marp.app will work correctly.