### PR TITLE
Begin the page number from 1 even if used `paginate: hold` at the first page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Upgrade Node.js and dependent packages to the latest version ([#369](https://github.com/marp-team/marpit/pull/369))
 
+### Fixed
+
+- Begin the page number from 1 even if used `paginate: hold` at the first page ([#365](https://github.com/marp-team/marpit/issues/365), [#370](https://github.com/marp-team/marpit/pull/370))
+
 ## v2.5.0 - 2023-06-06
 
 ### Added

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -103,6 +103,10 @@ function _apply(md, opts = {}) {
             marpitDirectives.paginate &&
             marpitDirectives.paginate !== 'skip'
           ) {
+            // If the page number was still not incremented, mark this page as
+            // the first page.
+            if (pageNumber <= 0) pageNumber = 1
+
             token.attrSet('data-marpit-pagination', pageNumber)
             tokensForPaginationTotal.push(token)
           }
@@ -118,7 +122,7 @@ function _apply(md, opts = {}) {
         }
       }
 
-      // Set total page number to each slide
+      // Set total page number to each slide page that has pagination attribute
       for (const token of tokensForPaginationTotal) {
         token.attrSet('data-marpit-pagination-total', pageNumber)
       }

--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -34,28 +34,24 @@ function _apply(md, opts = {}) {
     (state) => {
       if (state.inlineMode) return
 
-      // compute the total number of skipped pages
-      let totalSkippedSlides = 0
+      let pageNumber = 0
+
+      const tokensForPaginationTotal = []
+
       for (const token of state.tokens) {
-        const { marpitDirectives } = token.meta || {}
-        if (
-          marpitDirectives &&
-          (marpitDirectives.paginate === 'hold' ||
-            marpitDirectives.paginate === 'skip')
-        ) {
-          totalSkippedSlides++
+        const { marpitDirectives, marpitSlideElement } = token.meta || {}
+
+        if (marpitSlideElement === 1) {
+          // `skip` and `hold` disable increment of the page number
+          if (
+            !(
+              marpitDirectives?.paginate === 'skip' ||
+              marpitDirectives?.paginate === 'hold'
+            )
+          ) {
+            pageNumber += 1
+          }
         }
-      }
-
-      // keep track of slides that were skipped using one of the following
-      // directives:
-      // `paginate: skip`, `_paginate: skip`,
-      // `paginate: hold`, or `_paginate: hold
-      let currentSkippedSlides = 0
-
-      for (const token of state.tokens) {
-        const { marpitDirectives, marpitSlide, marpitSlideTotal } =
-          token.meta || {}
 
         if (marpitDirectives) {
           const style = new InlineStyle(token.attrGet('style'))
@@ -103,24 +99,12 @@ function _apply(md, opts = {}) {
               style.set('background-size', marpitDirectives.backgroundSize)
           }
 
-          if (marpitDirectives.paginate) {
-            if (
-              marpitDirectives.paginate === 'hold' ||
-              marpitDirectives.paginate === 'skip'
-            ) {
-              currentSkippedSlides++
-            }
-
-            if (marpitDirectives.paginate !== 'skip') {
-              token.attrSet(
-                'data-marpit-pagination',
-                marpitSlide - currentSkippedSlides + 1,
-              )
-              token.attrSet(
-                'data-marpit-pagination-total',
-                marpitSlideTotal - totalSkippedSlides,
-              )
-            }
+          if (
+            marpitDirectives.paginate &&
+            marpitDirectives.paginate !== 'skip'
+          ) {
+            token.attrSet('data-marpit-pagination', pageNumber)
+            tokensForPaginationTotal.push(token)
           }
 
           if (marpitDirectives.header)
@@ -132,6 +116,11 @@ function _apply(md, opts = {}) {
           const styleStr = style.toString()
           if (styleStr !== '') token.attrSet('style', styleStr)
         }
+      }
+
+      // Set total page number to each slide
+      for (const token of tokensForPaginationTotal) {
+        token.attrSet('data-marpit-pagination-total', pageNumber)
       }
     },
   )

--- a/src/markdown/directives/directives.js
+++ b/src/markdown/directives/directives.js
@@ -67,6 +67,8 @@ export const globals = Object.assign(Object.create(null), {
  * @prop {Directive} header Specify the content of slide header. It will insert
  *     a `<header>` element to the first of each slide contents.
  * @prop {Directive} paginate Show page number on the slide if you set `true`.
+ *     `hold` and `skip` are also available to disable increment of the page
+ *     number.
  */
 export const locals = Object.assign(Object.create(null), {
   backgroundColor: (v) => ({ backgroundColor: v }),
@@ -78,11 +80,13 @@ export const locals = Object.assign(Object.create(null), {
   color: (v) => ({ color: v }),
   footer: (v) => (typeof v === 'string' ? { footer: v } : {}),
   header: (v) => (typeof v === 'string' ? { header: v } : {}),
-  paginate: (v) => ({
-    paginate: ['hold', 'skip'].includes(v)
-      ? v
-      : (v || '').toLowerCase() === 'true',
-  }),
+  paginate: (v) => {
+    const normalized = (v || '').toLowerCase()
+
+    if (['hold', 'skip'].includes(normalized)) return { paginate: normalized }
+
+    return { paginate: normalized === 'true' }
+  },
 })
 
 export default [...Object.keys(globals), ...Object.keys(locals)]

--- a/test/markdown/directives/apply.js
+++ b/test/markdown/directives/apply.js
@@ -239,7 +239,7 @@ describe('Marpit directives apply plugin', () => {
     })
 
     describe('Paginate with skipped slides', () => {
-      it('applies data-marpit-pagination attribute with a _paginate:hold slide', () => {
+      it('applies data-marpit-pagination attribute with a _paginate: hold slide', () => {
         const paginateDirs = dedent`
           ---
           paginate: true
@@ -281,7 +281,7 @@ describe('Marpit directives apply plugin', () => {
         expect(sections.eq(2).data('marpit-pagination-total')).toBe(2)
       })
 
-      it('applies data-marpit-pagination attribute with a _paginate:skip slide', () => {
+      it('applies data-marpit-pagination attribute with a _paginate: skip slide', () => {
         const paginateDirs = dedent`
           ---
           paginate: true
@@ -321,6 +321,58 @@ describe('Marpit directives apply plugin', () => {
         expect(sections.eq(1).data('marpit-pagination-total')).toBeUndefined()
         expect(sections.eq(2).data('marpit-pagination')).toBe(2)
         expect(sections.eq(2).data('marpit-pagination-total')).toBe(2)
+      })
+
+      context('when paginate: hold is applied from beginning', () => {
+        const paginateDirs = dedent`
+          ---
+          paginate: hold
+          ---
+
+          # Slide 1
+
+          - Page is not incremented (1 of 3)
+          - Pagination rendered
+
+          ---
+
+          ## Slide 2
+
+          - Page is not incremented (1 of 3)
+          - Pagination rendered
+
+          ---
+
+          <!-- paginate: true -->
+
+          ## Slide 3
+
+          - Page is incremented (2 of 3)
+          - Pagination rendered
+
+          ---
+
+          <!-- paginate: false -->
+
+          ## Slide 4
+
+          - Page is incremented (3 of 3)
+          - Pagination is not rendered
+        `
+
+        it('applies data-marpit-pagination and data-marpit-pagination-total attribute correctly', () => {
+          const $ = load(mdForTest().render(paginateDirs))
+          const sections = $('section')
+
+          expect(sections.eq(0).data('marpit-pagination')).toBe(1)
+          expect(sections.eq(0).data('marpit-pagination-total')).toBe(3)
+          expect(sections.eq(1).data('marpit-pagination')).toBe(1)
+          expect(sections.eq(1).data('marpit-pagination-total')).toBe(3)
+          expect(sections.eq(2).data('marpit-pagination')).toBe(2)
+          expect(sections.eq(2).data('marpit-pagination-total')).toBe(3)
+          expect(sections.eq(3).data('marpit-pagination')).toBeUndefined()
+          expect(sections.eq(3).data('marpit-pagination-total')).toBeUndefined()
+        })
       })
     })
   })


### PR DESCRIPTION
Fix #365.

I refactored how to assign page numbers for making more clear and easy to read. :)