### PR TITLE
Fix blocking `paginate: skip` and `hold` in v2.5.1 inline SVG mode

### DIFF
--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -39,9 +39,9 @@ function _apply(md, opts = {}) {
       const tokensForPaginationTotal = []
 
       for (const token of state.tokens) {
-        const { marpitDirectives, marpitSlideElement } = token.meta || {}
+        const { marpitDirectives } = token.meta || {}
 
-        if (marpitSlideElement === 1) {
+        if (token.type === 'marpit_slide_open') {
           // `skip` and `hold` disable increment of the page number
           if (
             !(


### PR DESCRIPTION
The refactored pagination logic in #370 was prevented working `paginate: skip` and `paginate: hold` when enabled inline SVG mode.