### PR TITLE
`cssContainerQuery` constructor option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `cssContainerQuery` constructor option ([#355](https://github.com/marp-team/marpit/issues/355), [#377](https://github.com/marp-team/marpit/pull/377))
 - `lang` global directive and constructor option ([#376](https://github.com/marp-team/marpit/pull/376))
 
 ### Changed

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   testEnvironment: 'node',
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.js$',
   moduleFileExtensions: ['js', 'json', 'node'],
+  prettierPath: null,
 }

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -22,6 +22,7 @@ import ThemeSet from './theme_set'
 const defaultOptions = {
   anchor: true,
   container: marpitContainer,
+  cssContainerQuery: false,
   headingDivider: false,
   lang: undefined,
   looseYAML: false,
@@ -68,6 +69,10 @@ class Marpit {
    * @param {false|Element|Element[]}
    *     [opts.container={@link module:element.marpitContainer}] Container
    *     element(s) wrapping whole slide deck.
+   * @param {boolean|string|string[]} [opts.cssContainerQuery=false] Set whether
+   *     to enable CSS container query (`@container`). By setting the string or
+   *     string array, you can specify the container name(s) for the CSS
+   *     container.
    * @param {false|number|number[]} [opts.headingDivider=false] Start a new
    *     slide page at before of headings. it would apply to headings whose
    *     larger than or equal to the specified level if a number is given, or
@@ -264,6 +269,7 @@ class Marpit {
       ],
       inlineSVG: this.inlineSVGOptions,
       printable: this.options.printable,
+      containerQuery: this.options.cssContainerQuery,
     }
   }
 

--- a/src/postcss/container_query.js
+++ b/src/postcss/container_query.js
@@ -1,0 +1,53 @@
+/** @module */
+import cssesc from 'cssesc'
+import postcssPlugin from '../helpers/postcss_plugin'
+
+const reservedNames = [
+  'none',
+  'inherit',
+  'initial',
+  'revert',
+  'revert-layer',
+  'unset',
+]
+
+/**
+ * Marpit PostCSS container query plugin.
+ *
+ * Add support of container queries for child elements of the `section` element.
+ * (`@container` at-rule, and `cqw` `cqh` `cqi` `cqb` `cqmin` `cqmax` units)
+ *
+ * @function meta
+ * @param {string|string[]} [containerName=undefined] Container name
+ * @param {boolean} [escape=true] Set whether to escape container name
+ */
+export const containerQuery = postcssPlugin(
+  'marpit-postcss-container-query',
+  (containerName = undefined, escape = true) =>
+    (css) => {
+      const containerNames = (
+        Array.isArray(containerName) ? containerName : [containerName]
+      ).filter((name) => name && !reservedNames.includes(name))
+
+      const containerNameDeclaration =
+        containerNames.length > 0
+          ? `\n  container-name: ${containerNames
+              .map((name) =>
+                escape
+                  ? cssesc(name.toString(), { isIdentifier: true })
+                  : name.toString(),
+              )
+              .join(' ')};`
+          : ''
+
+      css.first.before(
+        `
+:where(section) {
+  container-type: size;${containerNameDeclaration}
+}
+`.trim(),
+      )
+    },
+)
+
+export default containerQuery

--- a/src/postcss/container_query.js
+++ b/src/postcss/container_query.js
@@ -11,6 +11,8 @@ const reservedNames = [
   'unset',
 ]
 
+const marpitContainerQueryPseudoMatcher = /\bsection:marpit-container-query\b/g
+
 /**
  * Marpit PostCSS container query plugin.
  *
@@ -40,14 +42,28 @@ export const containerQuery = postcssPlugin(
               .join(' ')};`
           : ''
 
-      css.first.before(
-        `
-:where(section) {
+      const style = `
+section:marpit-container-query {
   container-type: size;${containerNameDeclaration}
 }
-`.trim(),
-      )
+`.trim()
+
+      if (css.first) {
+        css.first.before(style)
+      } else {
+        css.append(style)
+      }
     },
+)
+
+export const postprocess = postcssPlugin(
+  'marpit-postcss-container-query-postprocess',
+  () => (css) =>
+    css.walkRules(marpitContainerQueryPseudoMatcher, (rule) => {
+      rule.selectors = rule.selectors.map((selector) =>
+        selector.replace(marpitContainerQueryPseudoMatcher, ':where(section)'),
+      )
+    }),
 )
 
 export default containerQuery

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -1,7 +1,9 @@
 import postcss from 'postcss'
 import postcssPlugin from './helpers/postcss_plugin'
 import postcssAdvancedBackground from './postcss/advanced_background'
-import postcssContainerQuery from './postcss/container_query'
+import postcssContainerQuery, {
+  postprocess as postcssContainerQueryPostProcess,
+} from './postcss/container_query'
 import postcssImportHoisting from './postcss/import/hoisting'
 import postcssImportReplace from './postcss/import/replace'
 import postcssImportSuppress from './postcss/import/suppress'
@@ -308,6 +310,7 @@ class ThemeSet {
         postcssPseudoReplace(opts.containers, slideElements),
         postcssRootIncreasingSpecificity,
         opts.printable && postcssPrintablePostProcess,
+        opts.containerQuery && postcssContainerQueryPostProcess,
         postcssRem,
         postcssImportHoisting,
       ].filter((p) => p),

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -1,6 +1,7 @@
 import postcss from 'postcss'
 import postcssPlugin from './helpers/postcss_plugin'
 import postcssAdvancedBackground from './postcss/advanced_background'
+import postcssContainerQuery from './postcss/container_query'
 import postcssImportHoisting from './postcss/import/hoisting'
 import postcssImportReplace from './postcss/import/replace'
 import postcssImportSuppress from './postcss/import/suppress'
@@ -236,6 +237,9 @@ class ThemeSet {
    * @param {string} [opts.before] A CSS string to prepend into before theme.
    * @param {Element[]} [opts.containers] Container elements wrapping whole
    *     slide deck.
+   * @param {boolean|string|string[]} [opts.containerQuery] Enable CSS container
+   *     query by setting `true`. You can also specify the name of container for
+   *     CSS container query used by the `@container` at-rule in child elements.
    * @param {boolean} [opts.printable] Make style printable to PDF.
    * @param {Marpit~InlineSVGOptions} [opts.inlineSVG] Apply a hierarchy of
    *     inline SVG to CSS selector by setting `true`. _(Experimental)_
@@ -263,6 +267,12 @@ class ThemeSet {
     const after = additionalCSS(opts.after)
     const before = additionalCSS(opts.before)
 
+    const containerName =
+      typeof opts.containerQuery === 'string' ||
+      Array.isArray(opts.containerQuery)
+        ? opts.containerQuery
+        : undefined
+
     const packer = postcss(
       [
         before &&
@@ -274,6 +284,7 @@ class ThemeSet {
           postcssPlugin('marpit-pack-after', () => (css) => {
             css.last.after(after)
           }),
+        opts.containerQuery && postcssContainerQuery(containerName),
         postcssImportHoisting,
         postcssImportReplace(this),
         opts.printable &&

--- a/test/marpit.js
+++ b/test/marpit.js
@@ -44,7 +44,9 @@ describe('Marpit', () => {
         expect(instance.options.anchor).toBe(true)
         expect(instance.options.container.tag).toBe('div')
         expect(instance.options.container.class).toBe('marpit')
-        expect(instance.options.markdown).toBe(undefined)
+        expect(instance.options.cssContainerQuery).toBe(false)
+        expect(instance.options.lang).toBeUndefined()
+        expect(instance.options.markdown).toBeUndefined()
         expect(instance.options.printable).toBe(true)
         expect(instance.options.slideContainer).toBe(false)
         expect(instance.options.inlineSVG).toBe(false)
@@ -500,6 +502,36 @@ describe('Marpit', () => {
         const [token] = marpit.markdown.parse('')
 
         expect(token.attrGet('id')).toBe('custom-1')
+      })
+    })
+
+    context('with cssContainerQuery option', () => {
+      it('does not include container query style if cssContainerQuery was false', () => {
+        const { css } = new Marpit({ cssContainerQuery: false }).render('')
+        expect(css).not.toContain('container-type: size;')
+      })
+
+      it('includes container query style if cssContainerQuery was true', () => {
+        const { css } = new Marpit({ cssContainerQuery: true }).render('')
+        expect(css).toContain('container-type: size;')
+      })
+
+      it('includes container name style if cssContainerQuery was string', () => {
+        const { css } = new Marpit({ cssContainerQuery: 'test' }).render('')
+        expect(css).toContain('container-type: size;')
+        expect(css).toContain('container-name: test;')
+      })
+
+      it('includes space-separated container name style if cssContainerQuery was the array of strings', () => {
+        const { css } = new Marpit({ cssContainerQuery: ['a', 'b'] }).render('')
+        expect(css).toContain('container-type: size;')
+        expect(css).toContain('container-name: a b;')
+      })
+
+      it('does include container name style if cssContainerQuery was empty array', () => {
+        const { css } = new Marpit({ cssContainerQuery: [] }).render('')
+        expect(css).toContain('container-type: size;')
+        expect(css).not.toContain('container-name')
       })
     })
   })

--- a/test/postcss/container_query.js
+++ b/test/postcss/container_query.js
@@ -1,0 +1,82 @@
+import postcss from 'postcss'
+import { containerQuery, postprocess } from '../../src/postcss/container_query'
+import { findDecl, findRule } from '../_supports/postcss_finder'
+
+describe('Marpit PostCSS container query plugin', () => {
+  const run = (input, args = []) =>
+    postcss([containerQuery(...args), postprocess]).process(input, {
+      from: undefined,
+    })
+
+  it('prepends style for container query', async () => {
+    const css = await run('section { width: 1280px; height: 960px; }')
+
+    expect(css.css).toMatchInlineSnapshot(`
+":where(section) {
+  container-type: size;
+}
+section { width: 1280px; height: 960px; }"
+`)
+  })
+
+  context('with container name', () => {
+    const findContainerNameDecl = (node) => {
+      const rule = findRule(node, {
+        selector: (selector) => selector.includes('section'),
+      })
+
+      return findDecl(rule, { prop: 'container-name' })
+    }
+
+    it('prepends style for container query with name', async () => {
+      const { root } = await run('', ['marpit'])
+
+      expect(findContainerNameDecl(root).value).toBe('marpit')
+    })
+
+    it('escapes container name', async () => {
+      const { root } = await run('', ['123 test'])
+
+      expect(findContainerNameDecl(root).value).toBe('\\31 23\\ test')
+    })
+
+    it('does not assign name if the name is empty', async () => {
+      const { root } = await run('', [''])
+
+      expect(findContainerNameDecl(root)).toBeFalsy()
+    })
+
+    it('does not assign name if the name has a reserved value', async () => {
+      for (const name of [
+        'none',
+        'inherit',
+        'initial',
+        'revert',
+        'revert-layer',
+        'unset',
+      ]) {
+        const { root } = await run('', [name])
+
+        expect(findContainerNameDecl(root)).toBeFalsy()
+      }
+    })
+
+    it('allows multiple names by passing array of strings', async () => {
+      const { root } = await run('', [['a', 'b', 'c']])
+
+      expect(findContainerNameDecl(root).value).toBe('a b c')
+    })
+
+    it('skips invalid name in array of strings', async () => {
+      const { root } = await run('', [['test', '', 'test2']])
+
+      expect(findContainerNameDecl(root).value).toBe('test test2')
+    })
+
+    it('does not assign name if the array of names is empty', async () => {
+      const { root } = await run('', [])
+
+      expect(findContainerNameDecl(root)).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
Added `cssContainerQuery` constructor option to support CSS container queries, `@container` at-rule and `cqw` `cqh` `cqi` `cqb` `cqmin` `cqmax` units for child elements of the slide element `section`.

```javascript
new Marpit({ cssContainerQuery: true })
```

```css
div.marpit > :where(section) {
  container-type: size;
}
```

By enabling this option, Marpit will become able to use features that related to CSS container queries, within both of the theme and the tweaked styles by Markdown.

```css
/* Container query */
@container (width > 1000px) {
  h1 {
    color: red;
  }
}

h1 {
  font-size: 5cqw; /* Container-based unit */
}
```

If passed string or array of strings to `cssContainerQuery`, Marpit will set the container name to identify the slide element in `@container` at-rule.

```javascript
new Marpit({ cssContainerQuery: 'marpit-slide' })
```

```css
div.marpit > :where(section) {
  container-type: size;
  container-name: marpit-slide;
}
```

If the `container-size` and `container-name` CSS declaration were already declared to `section` element through the theme CSS or tweaked styles, Marpit prefers them than the injected style by the constructor option. The injected style has low CSS specificity by using `:where` selector.

For keeping backward compatibillity, **`cssContainerQuery` constructor option is `false` by default** in Marpit v2. In downstream libraries and tools of Marp ecosystem, we may enable this option by default.

Resolves #355.