### PR TITLE
Add TypeScript definition for `cssContainerQuery` constructor option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Add TypeScript definition for `cssContainerQuery` constructor option ([#378](https://github.com/marp-team/marpit/pull/378))
+
 ## v2.6.0 - 2023-10-15
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace Marpit {
   interface Options {
     anchor?: boolean | AnchorCallback
     container?: false | Element | Element[]
+    cssContainerQuery?: boolean | string | string[]
     headingDivider?: false | HeadingDivider | HeadingDivider[]
     lang?: string
     looseYAML?: boolean


### PR DESCRIPTION
It's a missing part of v2.6.0 (#377).