### PR TITLE
[v3] Drop support against end-of-lifed Node.js versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
         default: []
       yarn:
         type: string
-        default: '^1.22.11'
+        default: '^1.22.19'
     steps:
       - run:
           name: Upgrade yarn for current user
@@ -100,24 +100,6 @@ jobs:
     steps:
       - audit
 
-  test-node14:
-    executor:
-      name: node
-      version: '14.18'
-    steps:
-      - prepare
-      - lint
-      - test
-
-  test-node16:
-    executor:
-      name: node
-      version: '16.18'
-    steps:
-      - prepare
-      - lint
-      - test
-
   test-node18:
     executor:
       name: node
@@ -127,16 +109,22 @@ jobs:
       - lint
       - test
 
+  test-node20:
+    executor:
+      name: node
+      version: '20.8'
+    steps:
+      - prepare
+      - lint
+      - test
+
 workflows:
   test:
     jobs:
       - audit
-      - test-node14:
-          requires:
-            - audit
-      - test-node16:
-          requires:
-            - audit
       - test-node18:
+          requires:
+            - audit
+      - test-node20:
           requires:
             - audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- Drop support against end-of-lifed Node.js versions (v16 and earlier) ([#291](https://github.com/marp-team/marpit/issues/291), [#380](https://github.com/marp-team/marpit/pull/380))
+
 ### Removed
 
 - Deprecated color setting shorthand via Markdown image syntax ([#331](https://github.com/marp-team/marpit/issues/331), [#379](https://github.com/marp-team/marpit/pull/379))

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,5 @@
 module.exports = {
-  // TODO: Drop support for EOL Node in Marpit v3
   presets: [
-    ['@babel/preset-env', { targets: { node: '10' }, shippedProposals: true }],
+    ['@babel/preset-env', { targets: { node: '18' }, shippedProposals: true }],
   ],
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/marp-team/marpit"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "main": "lib/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
We dropped support against EoL Node.js versions 10-16.

`@babel/preset-env` is now targeted Node.js 18, but I'm going to work for removing babel and replace the build step into rollup, for making ESM entrypoint.

Close #291.