### PR TITLE
Operators for class directive

### DIFF
--- a/src/markdown/directives/apply.js
+++ b/src/markdown/directives/apply.js
@@ -73,8 +73,26 @@ function _apply(md, opts = {}) {
           if (marpitDirectives.lang || lang)
             token.attrSet('lang', marpitDirectives.lang || lang)
 
-          if (marpitDirectives.class)
-            token.attrJoin('class', marpitDirectives.class)
+          if (marpitDirectives.class) {
+            token.attrJoin(
+              'class',
+              Array.from(
+                marpitDirectives.class
+                  .split(' ')
+                  .reduce(
+                    (acc, cur) => (
+                      cur.startsWith('+')
+                        ? acc.add(cur.substring(1))
+                        : cur.startsWith('-')
+                        ? acc.delete(cur.substring(1))
+                        : acc.add(cur),
+                      acc
+                    ),
+                    new Set(),
+                  ),
+              ).join(' '),
+            )
+          }
 
           if (marpitDirectives.color) style.set('color', marpitDirectives.color)
 


### PR DESCRIPTION
More control over classnames (as described here: https://github.com/marp-team/marpit/issues/233).

```js
var class = "invert pink embed"; // => "invert pink embed"
var class = "invert -pink embed"; // => "invert embed"
var class = "invert -pink embed +pink"; // => "invert embed pink"
```