### PR TITLE
Add `-webkit-text-size-adjust: 100%;` to the scaffold theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Drop support against end-of-lifed Node.js versions (v16 and earlier) ([#291](https://github.com/marp-team/marpit/issues/291), [#380](https://github.com/marp-team/marpit/pull/380))
 
+### Added
+
+- Add `-webkit-text-size-adjust: 100%;` to the scaffold theme ([#389](https://github.com/marp-team/marpit/pull/389))
+
 ### Removed
 
 - Deprecated color setting shorthand via Markdown image syntax ([#331](https://github.com/marp-team/marpit/issues/331), [#379](https://github.com/marp-team/marpit/pull/379))

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -12,6 +12,9 @@ section {
   position: relative;
 
   scroll-snap-align: center center;
+
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 section::after {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust

The mobile Safari browser may apply a text inflation algorithm to enlarge the text to make it more readable. This is better from a view of readability, but it would not keep rendering reproducibillity across several devices.

In this pull request, I've added `-webkit-text-size-adjust: 100%;` to the scaffold CSS declarations. It will disable text inflation algorithm explicitly, and keep the original text size.