### PR TITLE
Support for CSS nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for CSS nesting (`cssNesting` constructor option) ([#397](https://github.com/marp-team/marpit/issues/397), [#399](https://github.com/marp-team/marpit/pull/399))
+
 ### Changed
 
 - Upgrade development Node.js and dependent packages to the latest ([#398](https://github.com/marp-team/marpit/issues/398))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
+        "@csstools/postcss-is-pseudo-class": "^5.0.0",
         "cssesc": "^3.0.0",
         "js-yaml": "^4.1.0",
         "lodash.kebabcase": "^4.1.1",
         "markdown-it": "^14.1.0",
         "markdown-it-front-matter": "^0.2.4",
-        "postcss": "^8.4.41"
+        "postcss": "^8.4.41",
+        "postcss-nesting": "^13.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.25.6",
@@ -37,6 +39,7 @@
         "jsdoc": "^4.0.3",
         "npm-check-updates": "^17.1.0",
         "npm-run-all2": "^6.2.2",
+        "postcss-selector-parser": "^6.1.2",
         "prettier": "^3.3.3",
         "rimraf": "^6.0.1",
         "sass": "1.77.8",
@@ -2014,11 +2017,58 @@
         "@csstools/css-tokenizer": "^3.0.1"
       }
     },
+    "node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.0.tgz",
+      "integrity": "sha512-E/CjrT03BL06WmrjupnrT0VUBTvxJdoW1hRVeXFa9qatWtvcLLw0j8hP372G4A9PpSGEMXi3/AoHzPf7DNryCQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-specificity": "^4.0.0",
+        "postcss-selector-parser": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-2.0.0.tgz",
+      "integrity": "sha512-oklSrRvOxNeeOW1yARd4WNCs/D09cQjunGZUgSq6vM8GpzFswN+8rBZyJA29YFZhOTQ6GFzxgLDNtVbt9wPZMA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.1.0"
+      }
+    },
     "node_modules/@csstools/selector-specificity": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
       "integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9608,6 +9658,33 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-nesting": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.0.tgz",
+      "integrity": "sha512-TCGQOizyqvEkdeTPM+t6NYwJ3EJszYE/8t8ILxw/YoeUvz2rz7aM8XTAmBWh9/DJjfaaabL88fWrsVHSPF2zgA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-resolve-nested": "^2.0.0",
+        "@csstools/selector-specificity": "^4.0.0",
+        "postcss-selector-parser": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/postcss-normalize-charset": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.0.tgz",
@@ -9865,7 +9942,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11493,7 +11569,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "jsdoc": "^4.0.3",
     "npm-check-updates": "^17.1.0",
     "npm-run-all2": "^6.2.2",
+    "postcss-selector-parser": "^6.1.2",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "sass": "1.77.8",
@@ -88,12 +89,14 @@
     "ws": "^8.18.0"
   },
   "dependencies": {
+    "@csstools/postcss-is-pseudo-class": "^5.0.0",
     "cssesc": "^3.0.0",
     "js-yaml": "^4.1.0",
     "lodash.kebabcase": "^4.1.1",
     "markdown-it": "^14.1.0",
     "markdown-it-front-matter": "^0.2.4",
-    "postcss": "^8.4.41"
+    "postcss": "^8.4.41",
+    "postcss-nesting": "^13.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -23,6 +23,7 @@ const defaultOptions = {
   anchor: true,
   container: marpitContainer,
   cssContainerQuery: false,
+  cssNesting: true,
   headingDivider: false,
   lang: undefined,
   looseYAML: false,
@@ -73,6 +74,9 @@ class Marpit {
    *     to enable CSS container query (`@container`). By setting the string or
    *     string array, you can specify the container name(s) for the CSS
    *     container.
+   * @param {boolean} [opts.cssNesting=false] Enable CSS nesting support. If
+   *     enabled, Marpit will try to make flatten the CSS with nested rules
+   *     before rendering, to make it compatible with Marpit preprocessing.
    * @param {false|number|number[]} [opts.headingDivider=false] Start a new
    *     slide page at before of headings. it would apply to headings whose
    *     larger than or equal to the specified level if a number is given, or
@@ -128,7 +132,9 @@ class Marpit {
     /**
      * @type {ThemeSet}
      */
-    this.themeSet = new ThemeSet()
+    this.themeSet = new ThemeSet({
+      cssNesting: this.options.cssNesting,
+    })
 
     this.applyMarkdownItPlugins(
       (() => {
@@ -267,9 +273,9 @@ class Marpit {
         ...wrapArray(this.options.container),
         ...wrapArray(this.options.slideContainer),
       ],
+      containerQuery: this.options.cssContainerQuery,
       inlineSVG: this.inlineSVGOptions,
       printable: this.options.printable,
-      containerQuery: this.options.cssContainerQuery,
     }
   }
 

--- a/src/marpit.js
+++ b/src/marpit.js
@@ -76,7 +76,7 @@ class Marpit {
    *     container.
    * @param {boolean} [opts.cssNesting=false] Enable CSS nesting support. If
    *     enabled, Marpit will try to make flatten the CSS with nested rules
-   *     before rendering, to make it compatible with Marpit preprocessing.
+   *     before rendering, to make it compatible with Marpit preprocessings.
    * @param {false|number|number[]} [opts.headingDivider=false] Start a new
    *     slide page at before of headings. it would apply to headings whose
    *     larger than or equal to the specified level if a number is given, or

--- a/src/postcss/nesting.js
+++ b/src/postcss/nesting.js
@@ -1,0 +1,44 @@
+/** @module */
+import postcssPlugin from '../helpers/postcss_plugin'
+import postcssNesting from 'postcss-nesting'
+import postcssIsPseudoClass from '@csstools/postcss-is-pseudo-class'
+
+const { Rule: applyPostCSSNesting } = postcssNesting()
+
+const matcher = /:is\((?:section|:root)\b/
+
+export const nesting = postcssPlugin(
+  'marpit-postcss-nesting',
+  () => (root, helpers) => {
+    const rules = []
+
+    // Note: Use walk instead of walkRules to include nested rules
+    root.walk((node) => {
+      if (node.type !== 'rule') return
+
+      rules.push(node)
+      node.__marpitNestingOriginalSelector = node.selector
+    })
+
+    // Apply postcss-nesting
+    root.walkRules((rule) => applyPostCSSNesting(rule, helpers))
+
+    const { Rule: applyPostCSSIsPseudoClass } = postcssIsPseudoClass({
+      onComplexSelector: 'warning',
+    }).prepare()
+
+    for (const rule of rules) {
+      if (
+        rule.__marpitNestingOriginalSelector !== rule.selector &&
+        matcher.test(rule.selector)
+      ) {
+        // Apply postcss-is-pseudo-class only to transformed rules that is
+        // including `:is() selector starting from `section` element or `:root`
+        // pseudo-class
+        applyPostCSSIsPseudoClass(rule, helpers)
+      }
+    }
+  },
+)
+
+export default nesting

--- a/src/postcss/nesting.js
+++ b/src/postcss/nesting.js
@@ -37,6 +37,8 @@ export const nesting = postcssPlugin(
         // pseudo-class
         applyPostCSSIsPseudoClass(rule, helpers)
       }
+
+      delete rule.__marpitNestingOriginalSelector
     }
   },
 )

--- a/src/postcss/nesting.js
+++ b/src/postcss/nesting.js
@@ -1,7 +1,7 @@
 /** @module */
-import postcssPlugin from '../helpers/postcss_plugin'
-import postcssNesting from 'postcss-nesting'
 import postcssIsPseudoClass from '@csstools/postcss-is-pseudo-class'
+import postcssNesting from 'postcss-nesting'
+import postcssPlugin from '../helpers/postcss_plugin'
 
 const { Rule: applyPostCSSNesting } = postcssNesting()
 

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -7,6 +7,7 @@ import postcssContainerQuery, {
 import postcssImportHoisting from './postcss/import/hoisting'
 import postcssImportReplace from './postcss/import/replace'
 import postcssImportSuppress from './postcss/import/suppress'
+import postcssNesting from './postcss/nesting'
 import postcssPagination from './postcss/pagination'
 import postcssPrintable, {
   postprocess as postcssPrintablePostProcess,
@@ -23,6 +24,10 @@ import postcssSVGBackdrop from './postcss/svg_backdrop'
 import Theme from './theme'
 import scaffold from './theme/scaffold'
 
+const defaultOptions = {
+  cssNesting: false,
+}
+
 /**
  * Marpit theme set class.
  */
@@ -30,7 +35,7 @@ class ThemeSet {
   /**
    * Create a ThemeSet instance.
    */
-  constructor() {
+  constructor(opts = defaultOptions) {
     /**
      * An instance of default theme.
      *
@@ -84,6 +89,14 @@ class ThemeSet {
      */
     this.metaType = {}
 
+    /**
+     * A boolean value indicating whether the theme set should enable CSS
+     * nesting or not.
+     *
+     * @type {boolean}
+     */
+    this.cssNesting = !!opts.cssNesting
+
     Object.defineProperty(this, 'themeMap', { value: new Map() })
   }
 
@@ -106,7 +119,10 @@ class ThemeSet {
    *     metadata.
    */
   add(css) {
-    const theme = Theme.fromCSS(css, { metaType: this.metaType })
+    const theme = Theme.fromCSS(css, {
+      metaType: this.metaType,
+      cssNesting: this.cssNesting,
+    })
 
     this.addTheme(theme)
     return theme
@@ -256,11 +272,16 @@ class ThemeSet {
       slideElements.unshift({ tag: 'svg' }, { tag: 'foreignObject' })
     }
 
+    const runPostCSS = (css, plugins) =>
+      postcss(
+        [this.cssNesting && postcssNesting(), ...plugins].filter((p) => p),
+      ).process(css).css
+
     const additionalCSS = (css) => {
       if (!css) return undefined
 
       try {
-        return postcss([postcssImportSuppress(this)]).process(css).css
+        return runPostCSS(css, [postcssImportSuppress(this)])
       } catch {
         return undefined
       }
@@ -275,48 +296,44 @@ class ThemeSet {
         ? opts.containerQuery
         : undefined
 
-    const packer = postcss(
-      [
-        before &&
-          postcssPlugin(
-            'marpit-pack-before',
-            () => (css) => css.first.before(before),
-          ),
-        after &&
-          postcssPlugin('marpit-pack-after', () => (css) => {
-            css.last.after(after)
-          }),
-        opts.containerQuery && postcssContainerQuery(containerName),
-        postcssImportHoisting,
-        postcssImportReplace(this),
-        opts.printable &&
-          postcssPrintable({
-            width: this.getThemeProp(theme, 'width'),
-            height: this.getThemeProp(theme, 'height'),
-          }),
-        theme !== scaffold &&
-          postcssPlugin(
-            'marpit-pack-scaffold',
-            () => (css) => css.first.before(scaffold.css),
-          ),
-        inlineSVGOpts.enabled && postcssAdvancedBackground,
-        inlineSVGOpts.enabled &&
-          inlineSVGOpts.backdropSelector &&
-          postcssSVGBackdrop,
-        postcssPagination,
-        postcssRootReplace({ pseudoClass }),
-        postcssRootFontSize,
-        postcssPseudoPrepend,
-        postcssPseudoReplace(opts.containers, slideElements),
-        postcssRootIncreasingSpecificity,
-        opts.printable && postcssPrintablePostProcess,
-        opts.containerQuery && postcssContainerQueryPostProcess,
-        postcssRem,
-        postcssImportHoisting,
-      ].filter((p) => p),
-    )
-
-    return packer.process(theme.css).css
+    return runPostCSS(theme.css, [
+      before &&
+        postcssPlugin(
+          'marpit-pack-before',
+          () => (css) => css.first.before(before),
+        ),
+      after &&
+        postcssPlugin('marpit-pack-after', () => (css) => {
+          css.last.after(after)
+        }),
+      opts.containerQuery && postcssContainerQuery(containerName),
+      postcssImportHoisting,
+      postcssImportReplace(this),
+      opts.printable &&
+        postcssPrintable({
+          width: this.getThemeProp(theme, 'width'),
+          height: this.getThemeProp(theme, 'height'),
+        }),
+      theme !== scaffold &&
+        postcssPlugin(
+          'marpit-pack-scaffold',
+          () => (css) => css.first.before(scaffold.css),
+        ),
+      inlineSVGOpts.enabled && postcssAdvancedBackground,
+      inlineSVGOpts.enabled &&
+        inlineSVGOpts.backdropSelector &&
+        postcssSVGBackdrop,
+      postcssPagination,
+      postcssRootReplace({ pseudoClass }),
+      postcssRootFontSize,
+      postcssPseudoPrepend,
+      postcssPseudoReplace(opts.containers, slideElements),
+      postcssRootIncreasingSpecificity,
+      opts.printable && postcssPrintablePostProcess,
+      opts.containerQuery && postcssContainerQueryPostProcess,
+      postcssRem,
+      postcssImportHoisting,
+    ])
   }
 
   /**

--- a/src/theme_set.js
+++ b/src/theme_set.js
@@ -34,6 +34,9 @@ const defaultOptions = {
 class ThemeSet {
   /**
    * Create a ThemeSet instance.
+   *
+   * @param {Object} [opts]
+   * @param {boolean} [opts.cssNesting=true] Enable CSS nesting support.
    */
   constructor(opts = defaultOptions) {
     /**
@@ -90,8 +93,8 @@ class ThemeSet {
     this.metaType = {}
 
     /**
-     * A boolean value indicating whether the theme set should enable CSS
-     * nesting or not.
+     * A boolean value indicating whether the theme set is enabling CSS nesting
+     * or not.
      *
      * @type {boolean}
      */

--- a/test/_supports/selector_normalizer.js
+++ b/test/_supports/selector_normalizer.js
@@ -1,0 +1,25 @@
+import postcss from 'postcss'
+import parser from 'postcss-selector-parser'
+
+const selectorProcessor = parser()
+
+/**
+ * @param {string} selector Selector string.
+ */
+export const selectorNormalizer = (selector) =>
+  selectorProcessor.processSync(selector, { lossless: false })
+
+const cssNormalizer = (css) => {
+  const processor = postcss([
+    {
+      postcssPlugin: 'css-normalizer',
+      Rule(rule) {
+        rule.selectors = rule.selectors.map(selectorNormalizer)
+      },
+    },
+  ])
+
+  return processor.process(css, { from: undefined })
+}
+
+export const normalizeSelectorsInCss = (css) => cssNormalizer(css).css

--- a/test/postcss/root/replace.js
+++ b/test/postcss/root/replace.js
@@ -25,6 +25,9 @@ describe('Marpit PostCSS root replace plugin', () => {
     expect(run(':root:not(:root.klass) { --bg: #fff; }').css).toBe(
       'section:not(section.klass) { --bg: #fff; }',
     )
+    expect(run(':is(:root) { --bg: #fff; }').css).toBe(
+      ':is(section) { --bg: #fff; }',
+    )
     expect(
       run(dedent`
         @media screen {

--- a/test/theme_set.js
+++ b/test/theme_set.js
@@ -20,6 +20,21 @@ describe('ThemeSet', () => {
       expect(instance.themeMap).toBeInstanceOf(Map)
       expect({}.propertyIsEnumerable.call(instance, 'themeMap')).toBe(false)
     })
+
+    context('cssNesting option', () => {
+      it('has cssNesting property as false by default', () =>
+        expect(instance.cssNesting).toBe(false))
+
+      it('has cssNesting property as true when passed as true', () => {
+        instance = new ThemeSet({ cssNesting: true })
+        expect(instance.cssNesting).toBe(true)
+      })
+
+      it('has cssNesting property as false when passed as false', () => {
+        instance = new ThemeSet({ cssNesting: false })
+        expect(instance.cssNesting).toBe(false)
+      })
+    })
   })
 
   describe('get #size', () => {
@@ -52,7 +67,19 @@ describe('ThemeSet', () => {
 
     it('passes an empty metaType option to Theme.fromCSS', () => {
       instance.add('/* @theme a */')
-      expect(spy).toBeCalledWith('/* @theme a */', { metaType: {} })
+      expect(spy).toBeCalledWith(
+        '/* @theme a */',
+        expect.objectContaining({ metaType: {} }),
+      )
+    })
+
+    it('passes cssNesting option to Theme.fromCSS', () => {
+      instance.cssNesting = false
+      instance.add('/* @theme a */')
+      expect(spy).toBeCalledWith(
+        '/* @theme a */',
+        expect.objectContaining({ cssNesting: false }),
+      )
     })
 
     context("when ThemeSet's metaType property has changed", () => {
@@ -62,7 +89,10 @@ describe('ThemeSet', () => {
         instance.metaType = metaType
         instance.add('/* @theme c */')
 
-        expect(spy).toBeCalledWith('/* @theme c */', { metaType })
+        expect(spy).toBeCalledWith(
+          '/* @theme c */',
+          expect.objectContaining({ metaType }),
+        )
       })
     })
   })


### PR DESCRIPTION
Resolves #397.

Marpit now allows `cssNesting` constructor option, to enable or disable preprocessing for CSS nesting. The default value is `true`.

```javascript
new Marpit({ cssNesting: true }) // true by default
```

Currently Marpit has a lot of CSS manipulations, and some of them are not supported CSS nesting. Thus, I have taken the approach that will try to make flattennested CSS before rendering by using `postcss-nesting`. Developers can disable it by explicitly setting `cssNesting: false` as a constructor option.