### PR TITLE
Allow CSS `Q` unit as slide size definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support for CSS nesting (`cssNesting` constructor option) ([#397](https://github.com/marp-team/marpit/issues/397), [#399](https://github.com/marp-team/marpit/pull/399))
+- Allow CSS `Q` unit as slide size definitions ([#400](https://github.com/marp-team/marpit/pull/400))
 
 ### Changed
 

--- a/docs/theme-css.md
+++ b/docs/theme-css.md
@@ -93,7 +93,7 @@ section {
 }
 ```
 
-!> Please notice _it must define **the static length in an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, and `px`.
+!> Please notice _it must define **the static length in an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, `Q`, and `px`.
 
 ?> It is determined **one size per theme** in Marpit. The slide size cannot change through using [inline style](#tweak-style-through-markdown), [custom class](/directives#class), and [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). But the width of contents may shrink if user was using [split backgrounds](/image-syntax#split-backgrounds).
 

--- a/docs/theme-css.md
+++ b/docs/theme-css.md
@@ -93,7 +93,7 @@ section {
 }
 ```
 
-!> Please notice _it must define **the static length in an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, `Q`, and `px`.
+!> Please notice _it must define **the static length in an absolute unit.**_ We support `cm`, `in`, `mm`, `pc`, `pt`, `px`, and `Q`.
 
 ?> It is determined **one size per theme** in Marpit. The slide size cannot change through using [inline style](#tweak-style-through-markdown), [custom class](/directives#class), and [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). But the width of contents may shrink if user was using [split backgrounds](/image-syntax#split-backgrounds).
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -14,7 +14,7 @@ const absoluteUnits = {
   pc: (v) => v * 16,
   pt: (v) => (v * 4) / 3,
   px: (v) => v,
-  // q: (v) => (v * 24) / 25.4,
+  q: (v) => (v * 24) / 25.4,
 }
 
 const convertToPixel = (value) => {
@@ -27,7 +27,7 @@ const convertToPixel = (value) => {
   const parsed = Number.parseFloat(num)
   if (Number.isNaN(parsed)) return undefined
 
-  const conv = absoluteUnits[unit]
+  const conv = absoluteUnits[unit.toLowerCase()]
   return conv ? conv(parsed) : undefined
 }
 

--- a/test/theme.js
+++ b/test/theme.js
@@ -141,6 +141,7 @@ describe('Theme', () => {
       expect(instance('635mm').widthPixel).toBe(2400)
       expect(instance('8pc').widthPixel).toBe(128)
       expect(instance('300pt').widthPixel).toBe(400)
+      expect(instance('635Q').widthPixel).toBe(600)
     })
 
     it('returns undefined when width has not absolute unit', () => {


### PR DESCRIPTION
In Marpit, the absolute units are allowed as the slide size definition, but a relatively new unit `Q` (= `1/4 mm`) is not supported yet.