### PR TITLE
Update type definition to add `cssNesting` constructor option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Update type definition to add `cssNesting` constructor option ([#401](https://github.com/marp-team/marpit/pull/401))
+
 ## v3.1.0 - 2024-08-30
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare namespace Marpit {
     anchor?: boolean | AnchorCallback
     container?: false | Element | Element[]
     cssContainerQuery?: boolean | string | string[]
+    cssNesting?: boolean
     headingDivider?: false | HeadingDivider | HeadingDivider[]
     lang?: string
     looseYAML?: boolean
@@ -47,15 +48,20 @@ declare namespace Marpit {
     ...params: P
   ) => void
 
-  type ThemeReservedMeta = {
-    theme: string
-  }
-
   type ThemeMetaType = {
     [key: string]: StringConstructor | ArrayConstructor
   }
 
+  type ThemeReservedMeta = {
+    theme: string
+  }
+
+  interface ThemeSetOptions {
+    cssNesting?: boolean
+  }
+
   type ThemeOptions = {
+    cssNesting?: boolean
     metaType?: ThemeMetaType
   }
 
@@ -126,8 +132,9 @@ declare namespace Marpit {
   }
 
   export class ThemeSet {
-    constructor()
+    constructor(opts?: ThemeSetOptions)
 
+    cssNesting: boolean
     default: Theme | undefined
     metaType: ThemeMetaType
 


### PR DESCRIPTION
Marpit v3.1.0 has not included type definitions about `cssNesting` option.