### PR TITLE
Add `print-color-adjust` property to print CSS rendered by PostCSS printable plugin

### DIFF
--- a/src/postcss/printable.js
+++ b/src/postcss/printable.js
@@ -45,6 +45,7 @@ export const printable = postcssPlugin(
     animation-delay: 0s !important;
     animation-duration: 0s !important;
     color-adjust: exact !important;
+    print-color-adjust: exact !important;
     transition: none !important;
   }
 


### PR DESCRIPTION
Fix #410.