### PR TITLE
Scaffold theme: Don't overload UA's inline margin for `<h1>` element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Upgrade Node.js LTS and dependent packages to the latest version ([#413](https://github.com/marp-team/marpit/pull/413))
 
+### Fixed
+
+- Scaffold theme: Don't overload UA's inline margin for `<h1>` element ([#414](https://github.com/marp-team/marpit/pull/414))
+
 ## v3.1.2 - 2024-12-23
 
 ### Changed

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -33,7 +33,7 @@ section:not([data-marpit-pagination])::after {
 /* Normalization */
 h1 {
   font-size: 2em;
-  margin: 0.67em 0;
+  margin-block: 0.67em;
 }
 
 video::-webkit-media-controls {


### PR DESCRIPTION
This is a part of working to look over style of the scaffold theme, based on https://developer.mozilla.org/en-US/blog/h1-element-styles/.

<details>

Marpit always use `<section>` element as a container of the slide. `<h1>` in `<section>` had different UA style from `<h1>` on the root for a long time, so the scaffold theme has overloaded the style of `<h1>` for normalization.

In upcoming browser release, [the default UA style for `section h1` will be removed.](https://developer.mozilla.org/en-US/blog/h1-element-styles/#whats_changing) So the overloaded style will become no longer required in theory.

However, MDN describes the best practice is **required to define `font-size` and `margin` for `<h1>`**, and lacked definitions will affect to Lighthouse score.

Thus, we have decided _not to remove_ the current normalization styles for `<h1>`. Instead, we will update the style to match with [the recommendation by browser vendors](https://developer.mozilla.org/en-US/blog/h1-element-styles/#fixing_the_lighthouse_warning): `margin: 0.67em 0` :arrow_forward: `margin-block: 0.67em`

</details>