### PR TITLE
Make H1 style normalization overloadable using the universal selector `*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Upgrade development Node.js to v26 LTS ([#457](https://github.com/marp-team/marpit/pull/457))
 - Upgrade dependent packages to the latest version ([#438](https://github.com/marp-team/marpit/pull/438), [#440](https://github.com/marp-team/marpit/pull/440), [#457](https://github.com/marp-team/marpit/pull/457))
 
+### Fixed
+
+- Make `<h1>` style normalization overloadable using the universal selector `*` ([#443](https://github.com/marp-team/marpit/issues/443), [#458](https://github.com/marp-team/marpit/pull/458))
+
 ## v3.2.1 - 2026-02-28
 
 ### Changed

--- a/src/theme/scaffold.js
+++ b/src/theme/scaffold.js
@@ -31,7 +31,7 @@ section:not([data-marpit-pagination])::after {
 }
 
 /* Normalization */
-h1 {
+:where(h1) {
   font-size: 2em;
   margin-block: 0.67em;
 }


### PR DESCRIPTION
Fix #443 and https://github.com/marp-team/marp-vscode/issues/549.

By this change, the universal selector `*` in the custom theme can reset the default margin for `h1` specified in the scaffold theme, just like this:

```css
* {
  margin: 0;
}
```